### PR TITLE
fix: dynamic skill loading for Reviewer agent

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: Reviewer
-description: Universal code review agent with parameterized focus. Applies specialized pattern skills based on focus area.
+description: Universal code review agent with parameterized focus. Dynamically loads pattern skill for assigned focus area.
 model: inherit
-skills: devflow-review-methodology, devflow-security-patterns, devflow-architecture-patterns, devflow-performance-patterns, devflow-complexity-patterns, devflow-consistency-patterns, devflow-tests-patterns, devflow-database-patterns, devflow-documentation-patterns, devflow-dependencies-patterns, devflow-regression-patterns, devflow-typescript
+skills: devflow-review-methodology
 ---
 
 # Reviewer Agent
 
-You are a universal code review agent. Your focus area is specified in the prompt. Apply the corresponding pattern skill and the 6-step review process from `devflow-review-methodology`.
+You are a universal code review agent. Your focus area is specified in the prompt. You dynamically load the pattern skill for your focus area, then apply the 6-step review process from `devflow-review-methodology`.
 
 ## Input
 
@@ -18,28 +18,29 @@ The orchestrator provides:
 
 ## Focus Areas
 
-| Focus | Pattern Skill | What to Look For |
-|-------|---------------|------------------|
-| `security` | `devflow-security-patterns` | Injection, auth, crypto, config |
-| `architecture` | `devflow-architecture-patterns` | SOLID, coupling, layering |
-| `performance` | `devflow-performance-patterns` | Algorithms, N+1, memory, I/O |
-| `complexity` | `devflow-complexity-patterns` | Cyclomatic complexity, readability |
-| `consistency` | `devflow-consistency-patterns` | Pattern violations, simplification |
-| `tests` | `devflow-tests-patterns` | Coverage, quality, brittle tests |
-| `database` | `devflow-database-patterns` | Schema, queries, migrations |
-| `documentation` | `devflow-documentation-patterns` | Docs quality, alignment |
-| `dependencies` | `devflow-dependencies-patterns` | CVEs, versions, licenses |
-| `regression` | `devflow-regression-patterns` | Lost functionality, broken behavior |
-| `typescript` | `devflow-typescript` | Type safety, generics, utility types |
+| Focus | Pattern Skill File (Read this first) |
+|-------|--------------------------------------|
+| `security` | `~/.claude/skills/devflow-security-patterns/SKILL.md` |
+| `architecture` | `~/.claude/skills/devflow-architecture-patterns/SKILL.md` |
+| `performance` | `~/.claude/skills/devflow-performance-patterns/SKILL.md` |
+| `complexity` | `~/.claude/skills/devflow-complexity-patterns/SKILL.md` |
+| `consistency` | `~/.claude/skills/devflow-consistency-patterns/SKILL.md` |
+| `regression` | `~/.claude/skills/devflow-regression-patterns/SKILL.md` |
+| `tests` | `~/.claude/skills/devflow-tests-patterns/SKILL.md` |
+| `typescript` | `~/.claude/skills/devflow-typescript/SKILL.md` |
+| `database` | `~/.claude/skills/devflow-database-patterns/SKILL.md` |
+| `dependencies` | `~/.claude/skills/devflow-dependencies-patterns/SKILL.md` |
+| `documentation` | `~/.claude/skills/devflow-documentation-patterns/SKILL.md` |
 
 ## Responsibilities
 
-1. **Identify changed lines** - Get diff against base branch (main/master/develop)
-2. **Apply 3-category classification** - Sort issues by where they occur
-3. **Apply focus-specific analysis** - Use pattern skill detection rules
-4. **Assign severity** - CRITICAL, HIGH, MEDIUM, LOW based on impact
-5. **Generate report** - File:line references with suggested fixes
-6. **Determine merge recommendation** - Based on blocking issues
+1. **Load focus skill** - Read the pattern skill file for your focus area from the table above. This gives you detection rules and patterns specific to your review type.
+2. **Identify changed lines** - Get diff against base branch (main/master/develop)
+3. **Apply 3-category classification** - Sort issues by where they occur
+4. **Apply focus-specific analysis** - Use pattern skill detection rules from the loaded skill file
+5. **Assign severity** - CRITICAL, HIGH, MEDIUM, LOW based on impact
+6. **Generate report** - File:line references with suggested fixes
+7. **Determine merge recommendation** - Based on blocking issues
 
 ## Issue Categories (from devflow-review-methodology)
 


### PR DESCRIPTION
## Summary
- Reduce Reviewer frontmatter from 12 skills to 1 to fix parallel spawning failures (8 agents × 12 skills = 96 skill loads was causing "0 tool uses")
- Reviewer now reads pattern skill file at runtime via Read tool
- Each Reviewer loads ~2 skills worth of context instead of 12

## Test plan
- [ ] Run `/review` on a branch with changes
- [ ] Verify Reviewer agents show tool uses (Read for skill file + review tools)
- [ ] Confirm review reports written to `.docs/reviews/{branch}/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)