### PR TITLE
feat: integrate Agent Teams across workflows with /debug command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent Teams integration** - Peer-to-peer agent collaboration across workflows
+  - `/review` uses adversarial review team with debate round and consensus findings
+  - `/implement` uses exploration and planning teams with debate, Shepherd↔Coder direct dialogue
+  - New `/debug` command for competing hypothesis investigation with agent teams
+  - `agent-teams` foundation skill with team spawning, challenge protocol, consensus formation
+  - `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` enabled in default settings
+  - Graceful fallback to parallel subagents when Agent Teams is unavailable
+- **`devflow-debug` plugin** - New plugin for bug investigation
+  - `/debug` command spawns 3-5 hypothesis investigators
+  - Adversarial debate where agents actively disprove each other's theories
+  - Root cause analysis report with confidence levels
 - **`accessibility` skill** - WCAG 2.1 AA patterns for keyboard navigation, ARIA, contrast
   - Iron Law: EVERY INTERACTION MUST BE POSSIBLE WITHOUT A MOUSE
   - Auto-triggers when creating UI components, forms, or interactive elements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,18 @@ When working on DevFlow code, understand that this toolkit is designed to enhanc
 
 ## Architecture Overview
 
-DevFlow is organized as a plugin marketplace with 7 self-contained plugins:
+DevFlow is organized as a plugin marketplace with 9 self-contained plugins:
 
 1. **CLI Tool** (`src/cli/`) - TypeScript-based installer with plugin selection
-2. **Shared Skills** (`shared/skills/`) - Single source of truth for all 25 skills
+2. **Shared Skills** (`shared/skills/`) - Single source of truth for all 28 skills
 3. **Shared Agents** (`shared/agents/`) - Single source of truth for 10 reusable agents
 4. **Plugins** (`plugins/`) - Self-contained packages with commands, agents, and skills
    - `devflow-specify` - Feature specification workflow
-   - `devflow-implement` - Complete task implementation lifecycle
-   - `devflow-review` - Comprehensive code review
+   - `devflow-implement` - Complete task implementation lifecycle (with Agent Teams)
+   - `devflow-review` - Comprehensive code review (with Agent Teams)
    - `devflow-resolve` - Review issue resolution
+   - `devflow-debug` - Competing hypothesis debugging (with Agent Teams)
+   - `devflow-self-review` - Self-review workflow
    - `devflow-catch-up` - Context restoration
    - `devflow-devlog` - Session logging
    - `devflow-core-skills` - Auto-activating quality enforcement
@@ -387,6 +389,7 @@ DevFlow uses a **tiered skills system** where skills serve as shared knowledge l
 | `github-patterns` | GitHub API patterns (rate limiting, PR comments, issue management, releases) | Git |
 | `implementation-patterns` | Common implementation patterns (CRUD, API endpoints, events, config, logging) | Coder |
 | `codebase-navigation` | Codebase exploration, entry points, data flow tracing, pattern discovery | Coder |
+| `agent-teams` | Agent Teams patterns for peer-to-peer collaboration, debate, consensus | /review, /implement, /debug |
 
 **Tier 1b: Pattern Skills** (domain expertise for Reviewer agent focus areas)
 
@@ -451,6 +454,7 @@ Every skill has a single, non-negotiable **Iron Law** - a core principle that mu
 | `docs-framework` | ALL ARTIFACTS FOLLOW NAMING CONVENTIONS |
 | `implementation-patterns` | FOLLOW EXISTING PATTERNS |
 | `codebase-navigation` | FIND PATTERNS BEFORE IMPLEMENTING |
+| `agent-teams` | TEAMMATES CHALLENGE EACH OTHER |
 
 **Pattern Skills (Reviewer focus areas):**
 
@@ -915,9 +919,11 @@ devflow/
 │   │   ├── agents/                   # GENERATED shared agents (gitignored)
 │   │   ├── skills/                   # GENERATED skills (gitignored)
 │   │   └── README.md
-│   ├── devflow-implement/            # Implementation plugin
-│   ├── devflow-review/               # Review plugin
+│   ├── devflow-implement/            # Implementation plugin (Agent Teams)
+│   ├── devflow-review/               # Review plugin (Agent Teams)
 │   ├── devflow-resolve/              # Resolution plugin
+│   ├── devflow-debug/                # Debugging plugin (Agent Teams)
+│   ├── devflow-self-review/          # Self-review plugin
 │   ├── devflow-catch-up/             # Context restoration plugin
 │   ├── devflow-devlog/               # Logging plugin
 │   └── devflow-core-skills/          # Auto-activate skills plugin
@@ -970,7 +976,7 @@ The `skills` and `agents` arrays declare which shared assets this plugin needs. 
 
 Skills and agents are **not duplicated** in the git repository. Instead:
 
-1. **Single source of truth**: All 25 skills live in `shared/skills/`, all 10 shared agents live in `shared/agents/`
+1. **Single source of truth**: All 28 skills live in `shared/skills/`, all 10 shared agents live in `shared/agents/`
 2. **Manifest declares needs**: Each plugin's `plugin.json` has `skills` and `agents` arrays
 3. **Build copies assets**: `npm run build:plugins` copies skills and agents to each plugin
 4. **Git ignores generated**: `plugins/*/skills/` and shared agent files are in `.gitignore`
@@ -1012,6 +1018,7 @@ If settings.json exists, prompts for confirmation before overwriting.
 - `statusLine` - Smart statusline with context percentage
 - `env.ENABLE_TOOL_SEARCH` - Deferred MCP tool loading (~85% token savings)
 - `env.ENABLE_LSP_TOOL` - Language Server Protocol support for code intelligence
+- `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` - Enable Agent Teams for peer-to-peer agent collaboration
 - `extraKnownMarketplaces` - DevFlow plugin marketplace (`dean0x/devflow`)
 - `permissions.deny` - Security deny list (126 blocked operations) + sensitive file patterns
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ npx devflow-kit init --plugin=implement,review
 | Plugin | Command | Description |
 |--------|---------|-------------|
 | `devflow-specify` | `/specify` | Interactive feature specification with clarification gates |
-| `devflow-implement` | `/implement` | Complete task lifecycle (explore → plan → implement → validate) |
-| `devflow-review` | `/review` | Comprehensive code review with multiple focus areas |
+| `devflow-implement` | `/implement` | Complete task lifecycle with team-based exploration and planning |
+| `devflow-review` | `/review` | Adversarial code review with team debate and consensus |
 | `devflow-resolve` | `/resolve` | Process review issues - fix or defer to tech debt |
+| `devflow-debug` | `/debug` | Competing hypothesis debugging with agent teams |
+| `devflow-self-review` | `/self-review` | Self-review workflow (Simplifier + Scrutinizer) |
 | `devflow-catch-up` | `/catch-up` | Context restoration from status logs |
 | `devflow-devlog` | `/devlog` | Development session logging |
 | `devflow-core-skills` | (auto) | Auto-activating quality enforcement skills |
@@ -61,30 +63,36 @@ Creates a GitHub issue with well-defined requirements ready for `/implement`.
 
 Executes a single task through the complete development lifecycle:
 
-1. **Exploration** - Understand the codebase and find relevant patterns
-2. **Planning** - Design the implementation approach
+1. **Exploration** - Agent team explores codebase with debate on findings
+2. **Planning** - Agent team designs approach with adversarial challenge
 3. **Implementation** - Write the code on a feature branch
 4. **Validation** - Run build, typecheck, lint, and tests
 5. **Refinement** - Simplify and review for quality
-6. **Alignment Check** - Verify implementation matches the original request
+6. **Alignment Check** - Shepherd↔Coder direct dialogue validates alignment
 
 Creates a PR when complete.
 
 ### /review
 
-Performs comprehensive code review across multiple focus areas:
+Performs adversarial code review where reviewers debate findings:
 
-- Security vulnerabilities
-- Architecture and design patterns
-- Performance issues
-- Code complexity
-- Test coverage and quality
-- Database patterns
-- Documentation alignment
-- Dependency risks
-- Regression detection
+- Security, Architecture, Performance, and Quality perspectives
+- Conditional: TypeScript, React, Accessibility, Database, Dependencies, Documentation
+- Reviewers challenge each other's findings with evidence
+- Findings classified by consensus: HIGH / MEDIUM / LOW confidence
 
-Provides actionable feedback with severity levels and specific fixes.
+Provides actionable feedback with severity levels, confidence, and specific fixes.
+
+### /debug
+
+Investigates bugs using competing hypotheses with an agent team:
+
+1. **Hypothesis Generation** - Identify 3-5 plausible explanations
+2. **Parallel Investigation** - Each agent investigates one hypothesis
+3. **Adversarial Debate** - Agents try to disprove each other's theories
+4. **Convergence** - Root cause is the hypothesis that survives scrutiny
+
+Produces a root cause analysis report with confidence level.
 
 ### /resolve
 
@@ -155,9 +163,15 @@ DevFlow creates project documentation in `.docs/`:
 /implement   # Execute the full lifecycle
 ```
 
+### Debugging an Issue
+```bash
+/debug "login fails after session timeout"
+/debug #42   # Investigate from GitHub issue
+```
+
 ### Before Creating a PR
 ```bash
-/review      # Comprehensive review across all focus areas
+/review      # Adversarial review with team debate
 /resolve     # Fix low-risk issues, defer high-risk to backlog
 ```
 

--- a/plugins/devflow-debug/.claude-plugin/plugin.json
+++ b/plugins/devflow-debug/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "devflow-debug",
+  "description": "Debugging workflows with competing hypothesis investigation using agent teams",
+  "author": {
+    "name": "DevFlow Contributors",
+    "email": "dean@keren.dev"
+  },
+  "version": "0.9.0",
+  "homepage": "https://github.com/dean0x/devflow",
+  "repository": "https://github.com/dean0x/devflow",
+  "license": "MIT",
+  "keywords": ["debugging", "hypotheses", "investigation", "agent-teams"],
+  "agents": ["git"],
+  "skills": [
+    "agent-teams",
+    "git-safety"
+  ]
+}

--- a/plugins/devflow-debug/README.md
+++ b/plugins/devflow-debug/README.md
@@ -1,0 +1,65 @@
+# devflow-debug
+
+Debugging workflow plugin for Claude Code. Investigates bugs using competing hypotheses with agent teams for adversarial debate.
+
+## Installation
+
+```bash
+# Via DevFlow CLI
+npx devflow-kit init --plugin=debug
+
+# Via Claude Code (when available)
+/plugin install dean0x/devflow-debug
+```
+
+## Prerequisites
+
+Requires Agent Teams feature:
+- Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings (included in DevFlow settings)
+- Or install DevFlow with `--override-settings` to enable automatically
+
+## Usage
+
+```
+/debug "description of bug"
+/debug "login fails after session timeout"
+/debug #42   (investigate from GitHub issue)
+```
+
+## How It Works
+
+1. **Hypothesis Generation** - Analyzes the bug and generates 3-5 distinct hypotheses
+2. **Team Spawning** - Creates one investigator agent per hypothesis
+3. **Parallel Investigation** - Each agent independently gathers evidence
+4. **Adversarial Debate** - Agents challenge each other's findings with code evidence
+5. **Convergence** - Hypotheses that survive scrutiny become the root cause
+6. **Report** - Root cause with confidence level, evidence, and fix recommendations
+
+## Components
+
+### Command
+- `/debug` - Competing hypothesis debugging
+
+### Skills
+- `agent-teams` - Team coordination patterns
+- `git-safety` - Safe git operations
+
+## Output
+
+Produces a root cause analysis report including:
+- Confirmed/disproved hypothesis summary
+- Key evidence with file:line references
+- Debate exchanges that led to conclusion
+- Recommended fix with confidence level
+
+## When to Use
+
+- Bugs with unclear root cause
+- Issues that could have multiple explanations
+- Intermittent failures where the mechanism is unknown
+- Complex bugs spanning multiple systems
+
+## Related Plugins
+
+- [devflow-review](../devflow-review) - Code review with team-based debate
+- [devflow-implement](../devflow-implement) - Implementation with team exploration

--- a/plugins/devflow-debug/commands/debug.md
+++ b/plugins/devflow-debug/commands/debug.md
@@ -1,0 +1,185 @@
+---
+description: Debug issues using competing hypothesis investigation with an agent team
+---
+
+# Debug Command
+
+Investigate bugs by spawning a team of agents, each pursuing a different hypothesis. Agents actively try to disprove each other's theories, converging on the root cause that survives scrutiny.
+
+## Usage
+
+```
+/debug "description of bug or issue"
+/debug "function returns undefined when called with empty array"
+/debug #42   (investigate bug from GitHub issue)
+```
+
+## Input
+
+`$ARGUMENTS` contains whatever follows `/debug`:
+- Bug description: "login fails after session timeout"
+- GitHub issue: "#42"
+- Empty: use conversation context
+
+## Phases
+
+### Phase 1: Context Gathering
+
+If `$ARGUMENTS` starts with `#`, fetch the GitHub issue:
+
+```
+Task(subagent_type="Git"):
+"OPERATION: fetch-issue
+ISSUE: {issue number}
+Return issue title, body, labels, and any linked error logs."
+```
+
+Analyze the bug description (from arguments or issue) and identify 3-5 plausible hypotheses. Each hypothesis must be:
+- **Specific**: Points to a concrete mechanism (not "something is wrong")
+- **Testable**: Can be confirmed or disproved by reading code/logs
+- **Distinct**: Does not overlap significantly with other hypotheses
+
+### Phase 2: Spawn Investigation Team
+
+Create an agent team with one investigator per hypothesis:
+
+```
+Create a team named "debug-{bug-slug}" to investigate: {bug_description}
+
+Spawn teammates:
+- "Investigator A: {hypothesis A description}"
+  Focus: {specific code area, mechanism, or condition to investigate}
+
+- "Investigator B: {hypothesis B description}"
+  Focus: {specific code area, mechanism, or condition to investigate}
+
+- "Investigator C: {hypothesis C description}"
+  Focus: {specific code area, mechanism, or condition to investigate}
+
+(Add more if bug complexity warrants 4-5 hypotheses)
+
+Each investigator:
+1. Read relevant code files
+2. Trace data flow related to their hypothesis
+3. Look for evidence that CONFIRMS or DISPROVES the hypothesis
+4. Document findings with file:line references
+```
+
+### Phase 3: Investigation
+
+Teammates investigate in parallel:
+- Read relevant source files
+- Trace execution paths
+- Check error handling
+- Look for edge cases and race conditions
+- Build evidence for or against their hypothesis
+
+### Phase 4: Adversarial Debate
+
+Lead broadcasts to all teammates:
+
+```
+"Investigation complete. Share your findings:
+1. State your hypothesis
+2. Present evidence FOR (with file:line references)
+3. Present evidence AGAINST
+4. Challenge at least one other investigator's hypothesis
+
+Rules:
+- You must try to DISPROVE other hypotheses, not just support your own
+- Cite specific code when challenging
+- If your hypothesis is disproved, acknowledge it
+- Max 2 exchange rounds before we converge"
+```
+
+Teammates message each other directly:
+- "My evidence at `src/auth.ts:42` disproves your hypothesis because..."
+- "Your theory doesn't explain why this only fails on Tuesdays..."
+- "I've updated my hypothesis based on your finding at..."
+
+### Phase 5: Convergence
+
+After debate (max 2 rounds), lead collects results:
+
+```
+Lead broadcast:
+"Debate complete. Each investigator: submit final status.
+- CONFIRMED: Your hypothesis survived scrutiny (evidence summary)
+- DISPROVED: Your hypothesis was invalidated (what disproved it)
+- PARTIAL: Some aspects confirmed, others not (details)"
+```
+
+### Phase 6: Cleanup
+
+Lead shuts down all teammates and calls cleanup.
+
+### Phase 7: Report
+
+Lead produces final report:
+
+```markdown
+## Root Cause Analysis: {bug description}
+
+### Root Cause (Consensus)
+{Description of the root cause that survived peer scrutiny}
+{Key evidence with file:line references}
+
+### Investigation Summary
+
+| Hypothesis | Status | Key Evidence |
+|-----------|--------|-------------|
+| A: {description} | CONFIRMED/DISPROVED/PARTIAL | {file:line + summary} |
+| B: {description} | CONFIRMED/DISPROVED/PARTIAL | {file:line + summary} |
+| C: {description} | CONFIRMED/DISPROVED/PARTIAL | {file:line + summary} |
+
+### Key Debate Exchanges
+{2-3 most important exchanges that led to the conclusion}
+
+### Recommended Fix
+{Concrete action items with file references}
+
+### Confidence Level
+{HIGH/MEDIUM/LOW based on consensus strength}
+```
+
+## Architecture
+
+```
+/debug (orchestrator)
+│
+├─ Phase 1: Context gathering
+│  └─ Git agent (fetch issue, if #N provided)
+│
+├─ Phase 2: Spawn investigation team
+│  └─ Create team with 3-5 hypothesis investigators
+│
+├─ Phase 3: Parallel investigation
+│  └─ Each teammate investigates independently
+│
+├─ Phase 4: Adversarial debate
+│  └─ Teammates challenge each other directly (max 2 rounds)
+│
+├─ Phase 5: Convergence
+│  └─ Teammates submit final hypothesis status
+│
+├─ Phase 6: Cleanup
+│  └─ Shut down teammates, release resources
+│
+└─ Phase 7: Root cause report with confidence level
+```
+
+## Principles
+
+1. **Competing hypotheses** - Never investigate a single theory; always have alternatives
+2. **Adversarial debate** - Agents must actively try to disprove each other
+3. **Evidence-based** - Every claim requires file:line references
+4. **Bounded debate** - Max 2 exchange rounds, then converge
+5. **Honest uncertainty** - If no hypothesis survives, report that clearly
+6. **Cleanup always** - Team resources released even on failure
+
+## Error Handling
+
+- If fewer than 3 hypotheses can be generated: proceed with 2, note limited scope
+- If all hypotheses are disproved: report "No root cause identified" with investigation summary
+- If team spawning fails: fall back to sequential subagent investigation (one per hypothesis)
+- If a teammate errors: continue with remaining teammates, note the gap

--- a/plugins/devflow-implement/.claude-plugin/plugin.json
+++ b/plugins/devflow-implement/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
   "agents": ["git", "skimmer", "synthesizer", "coder", "simplifier", "scrutinizer", "shepherd", "validator"],
   "skills": [
     "accessibility",
+    "agent-teams",
     "codebase-navigation",
     "frontend-design",
     "implementation-patterns",

--- a/plugins/devflow-implement/commands/implement.md
+++ b/plugins/devflow-implement/commands/implement.md
@@ -1,10 +1,10 @@
 ---
-description: Execute a single task through the complete lifecycle - orchestrates exploration, planning, implementation, and simplification with parallel agents
+description: Execute a single task through the complete lifecycle - orchestrates team-based exploration, planning, implementation, and quality gates
 ---
 
 # Implement Command
 
-Orchestrate a single task from exploration through implementation by spawning specialized agents. The orchestrator only spawns agents and passes context - all work is done by agents.
+Orchestrate a single task from exploration through implementation by spawning specialized agent teams for collaborative exploration and planning, then implementation agents for coding and quality gates.
 
 ## Usage
 
@@ -57,46 +57,89 @@ Task(subagent_type="Skimmer"):
 Use skim to identify relevant files, functions, integration points"
 ```
 
-### Phase 2: Explore (Parallel)
+### Phase 2: Exploration Team
 
-Spawn 4 Explore agents **in a single message**, each with Skimmer context:
+Create an agent team for collaborative codebase exploration:
 
-| Focus | Thoroughness | Find |
-|-------|-------------|------|
-| Architecture | medium | Similar implementations, patterns, module structure |
-| Integration | medium | Entry points, services, database models, configuration |
-| Reusable code | medium | Utilities, helpers, validation patterns, error handling |
-| Edge cases | quick | Error scenarios, race conditions, permission failures |
+```
+Create a team named "explore-{task-id}" to explore the codebase for: {task description}
 
-Track success/failure of each explorer for synthesis context.
+Spawn exploration teammates (with Skimmer context):
+
+- "Architecture Explorer"
+  Focus: Find similar implementations, established patterns, module structure.
+  Skimmer context: {skimmer output}
+
+- "Integration Explorer"
+  Focus: Find entry points, services, database models, configuration.
+  Skimmer context: {skimmer output}
+
+- "Reusable Code Explorer"
+  Focus: Find utilities, helpers, validation patterns, error handling to reuse.
+  Skimmer context: {skimmer output}
+
+- "Edge Case Explorer"
+  Focus: Find error scenarios, race conditions, permission failures, boundary cases.
+  Skimmer context: {skimmer output}
+
+After initial exploration, teammates debate:
+- Architecture challenges edge cases: "This boundary isn't handled by existing patterns"
+- Integration challenges reusable code: "That helper doesn't cover our integration point"
+- Edge cases challenges architecture: "This pattern fails under concurrent access"
+
+Max 2 debate rounds, then submit consensus exploration findings.
+```
+
+**Exploration team output**: Consensus findings on patterns, integration points, reusable code, edge cases.
+
+Shut down exploration team and clean up.
 
 ### Phase 3: Synthesize Exploration
 
-**WAIT** for Phase 2 to complete.
-
 **CRITICAL**: Do NOT synthesize outputs yourself in the main session.
-You MUST spawn the Synthesizer agent - "spawn Synthesizer" means delegate to the agent, not do the work yourself.
+You MUST spawn the Synthesizer agent.
 
 ```
 Task(subagent_type="Synthesizer"):
 "Synthesize EXPLORATION outputs for: {task}
 Mode: exploration
-Explorer outputs: {all 4 outputs}
-Failed explorations: {any failures}
+Explorer consensus: {team exploration consensus output}
 Combine into: patterns, integration points, reusable code, edge cases"
 ```
 
-### Phase 4: Plan (Parallel)
+### Phase 4: Planning Team
 
-Spawn 3 Plan agents **in a single message**, each with exploration synthesis:
+Create an agent team for collaborative implementation planning:
 
-| Focus | Output |
-|-------|--------|
-| Implementation steps | Ordered steps with files and dependencies |
-| Testing strategy | Unit tests, integration tests, edge case tests |
-| Execution strategy | SINGLE_CODER vs SEQUENTIAL_CODERS vs PARALLEL_CODERS decision |
+```
+Create a team named "plan-{task-id}" to plan implementation of: {task description}
 
-**Execution Strategy planner analyzes 3 axes:**
+Context from exploration: {synthesis output from Phase 3}
+
+Spawn planning teammates:
+
+- "Implementation Planner"
+  Focus: Step-by-step coding approach with files, dependencies, and order.
+  Exploration context: {synthesis}
+
+- "Testing Planner"
+  Focus: Test strategy - unit tests, integration tests, edge case coverage.
+  Exploration context: {synthesis}
+
+- "Risk & Execution Planner"
+  Focus: Potential issues, rollback strategy, and execution strategy decision
+  (SINGLE_CODER vs SEQUENTIAL_CODERS vs PARALLEL_CODERS).
+  Exploration context: {synthesis}
+
+After initial planning, teammates debate:
+- Testing challenges implementation: "This approach is untestable without major refactoring"
+- Risk challenges both: "Rollback is impossible with this migration strategy"
+- Implementation challenges testing: "Full coverage here adds 3x complexity for minimal value"
+
+Max 2 debate rounds, then submit consensus plan.
+```
+
+**Execution Strategy** (from Risk & Execution planner, validated by team):
 
 | Axis | Signals | Decision Impact |
 |------|---------|-----------------|
@@ -110,18 +153,18 @@ Spawn 3 Plan agents **in a single message**, each with exploration synthesis:
 - **HIGH**: 20-30 files, multiple modules → SEQUENTIAL_CODERS (2-3 phases)
 - **CRITICAL**: >30 files, cross-cutting concerns → SEQUENTIAL_CODERS (more phases)
 
+Shut down planning team and clean up.
+
 ### Phase 5: Synthesize Planning
 
-**WAIT** for Phase 4 to complete.
-
 **CRITICAL**: Do NOT synthesize outputs yourself in the main session.
-You MUST spawn the Synthesizer agent - "spawn Synthesizer" means delegate to the agent, not do the work yourself.
+You MUST spawn the Synthesizer agent.
 
 ```
 Task(subagent_type="Synthesizer"):
 "Synthesize PLANNING outputs for: {task}
 Mode: planning
-Planner outputs: {all 3 outputs}
+Planner consensus: {team planning consensus output}
 Combine into: execution plan with strategy decision (SINGLE_CODER | SEQUENTIAL_CODERS | PARALLEL_CODERS)"
 ```
 
@@ -135,7 +178,7 @@ Combine into: execution plan with strategy decision (SINGLE_CODER | SEQUENTIAL_C
 
 Based on Phase 5 synthesis, use the three-strategy framework:
 
-**Strategy Selection** (from Execution Strategy planner):
+**Strategy Selection** (from planning team consensus):
 
 | Strategy | When | Frequency |
 |----------|------|-----------|
@@ -300,9 +343,40 @@ Verify Scrutinizer's fixes didn't break anything."
 
 **If PASS:** Continue to Phase 9
 
-### Phase 9: Alignment Check
+### Phase 9: Shepherd↔Coder Dialogue
 
-After Scrutinizer passes (and re-validation if needed), spawn Shepherd to validate alignment:
+After Scrutinizer passes (and re-validation if needed), check alignment using direct dialogue when Agent Teams is available:
+
+**With Agent Teams:**
+
+Create a mini-team for alignment validation:
+
+```
+Create a team named "align-{task-id}" for alignment check.
+
+Spawn teammates:
+- "Shepherd"
+  Context: Validate implementation aligns with original request.
+  ORIGINAL_REQUEST: {task description or issue content}
+  EXECUTION_PLAN: {synthesized plan from Phase 5}
+  FILES_CHANGED: {list of files from Coder output}
+  ACCEPTANCE_CRITERIA: {extracted criteria if available}
+
+- "Coder"
+  Context: Respond to alignment concerns and fix issues.
+  TASK_ID: {task-id}
+  SCOPE: Fix only misalignments identified by Shepherd
+
+Rules:
+1. Shepherd analyzes alignment, sends findings to Coder
+2. Coder responds with fix or clarification
+3. Shepherd validates response
+4. Max 2 exchanges before escalating to lead
+```
+
+After dialogue completes, shut down alignment team.
+
+**Without Agent Teams (fallback):**
 
 ```
 Task(subagent_type="Shepherd"):
@@ -352,7 +426,7 @@ Display completion summary with phase status, PR info, and next steps.
 ## Architecture
 
 ```
-/implement (orchestrator - spawns agents only)
+/implement (orchestrator - spawns teams and agents)
 │
 ├─ Phase 1: Setup
 │  └─ Git agent (operation: setup-task) - creates feature branch, fetches issue
@@ -360,19 +434,21 @@ Display completion summary with phase status, PR info, and next steps.
 ├─ Phase 1.5: Orient
 │  └─ Skimmer agent (codebase overview via skim)
 │
-├─ Phase 2: Explore (PARALLEL, with Skimmer context)
-│  ├─ Explore: Architecture
-│  ├─ Explore: Integration
-│  ├─ Explore: Reusable code
-│  └─ Explore: Edge cases
+├─ Phase 2: Exploration Team (Agent Teams)
+│  ├─ Architecture Explorer (teammate)
+│  ├─ Integration Explorer (teammate)
+│  ├─ Reusable Code Explorer (teammate)
+│  ├─ Edge Case Explorer (teammate)
+│  └─ Debate → consensus exploration findings
 │
 ├─ Phase 3: Synthesize Exploration
 │  └─ Synthesizer agent (mode: exploration)
 │
-├─ Phase 4: Plan (PARALLEL)
-│  ├─ Plan: Implementation steps
-│  ├─ Plan: Testing strategy
-│  └─ Plan: Execution strategy (3-strategy decision)
+├─ Phase 4: Planning Team (Agent Teams)
+│  ├─ Implementation Planner (teammate)
+│  ├─ Testing Planner (teammate)
+│  ├─ Risk & Execution Planner (teammate)
+│  └─ Debate → consensus plan with strategy decision
 │
 ├─ Phase 5: Synthesize Planning
 │  └─ Synthesizer agent (mode: planning) → returns strategy + DOMAIN hints
@@ -395,9 +471,9 @@ Display completion summary with phase status, PR info, and next steps.
 ├─ Phase 8.5: Re-Validate (if Scrutinizer made changes)
 │  └─ Validator agent (verify Scrutinizer fixes)
 │
-├─ Phase 9: Alignment Check
-│  └─ Shepherd agent (validates alignment - reports only, no fixes)
-│  └─ If MISALIGNED: Coder fix loop (max 2 iterations) → Validator → re-check
+├─ Phase 9: Shepherd↔Coder Dialogue (Agent Teams) or Shepherd check (fallback)
+│  └─ With teams: direct Shepherd↔Coder messaging (max 2 exchanges)
+│  └─ Without teams: Shepherd subagent → Coder fix loop if misaligned
 │
 ├─ Phase 10: Create PR (if needed)
 │  └─ SINGLE_CODER: handled by Coder
@@ -409,18 +485,28 @@ Display completion summary with phase status, PR info, and next steps.
 
 ## Principles
 
-1. **Orchestration only** - Command spawns agents, never does work itself
-2. **Coherence-first** - Single Coder produces more consistent code (default ~80% of tasks)
-3. **Parallel exploration** - Explore and plan phases run in parallel; sequential phases wait
-4. **Agent ownership** - Each agent owns its output completely
-5. **Clean handoffs** - Each phase passes structured data to next; sequential Coders pass implementation summaries
-6. **Honest reporting** - Display agent outputs directly
-7. **Simplification pass** - Code refined for clarity before PR
-8. **Strict delegation** - Never perform agent work in main session. "Spawn X" means call Task tool with X, not do X's work yourself
-9. **Validator owns validation** - Never run `npm test`, `npm run build`, or similar in main session; always delegate to Validator agent
-10. **Coder owns fixes** - Never implement fixes in main session; spawn Coder for validation failures and alignment fixes
-11. **Loop limits** - Max 2 validation retries, max 2 alignment fix iterations before escalating to user
+1. **Orchestration only** - Command spawns teams/agents, never does work itself
+2. **Team-based exploration** - Exploration and planning use Agent Teams for debate
+3. **Coherence-first** - Single Coder produces more consistent code (default ~80% of tasks)
+4. **Bounded debate** - Max 2 exchange rounds in any team, then converge
+5. **Agent ownership** - Each agent owns its output completely
+6. **Clean handoffs** - Each phase passes structured data to next; sequential Coders pass implementation summaries
+7. **Honest reporting** - Display agent outputs directly
+8. **Simplification pass** - Code refined for clarity before PR
+9. **Strict delegation** - Never perform agent work in main session. "Spawn X" means call Task tool with X, not do X's work yourself
+10. **Validator owns validation** - Never run `npm test`, `npm run build`, or similar in main session; always delegate to Validator agent
+11. **Coder owns fixes** - Never implement fixes in main session; spawn Coder for validation failures and alignment fixes
+12. **Loop limits** - Max 2 validation retries, max 2 alignment fix iterations before escalating to user
+13. **Cleanup always** - Team resources released after exploration and planning phases
+
+## Fallback
+
+If Agent Teams is unavailable (feature not enabled):
+- Phase 2: Fall back to 4 parallel Explore subagents (current behavior)
+- Phase 4: Fall back to 3 parallel Plan subagents (current behavior)
+- Phase 9: Fall back to Shepherd subagent → orchestrator-mediated Coder fix loop
+- Note in report: "Implementation run without team debate (Agent Teams not available)"
 
 ## Error Handling
 
-If any agent fails, report the phase, agent type, and error. Offer options: retry phase, investigate systematically, or escalate to user.
+If any agent or team fails, report the phase, agent type, and error. Offer options: retry phase, investigate systematically, or escalate to user.

--- a/plugins/devflow-review/.claude-plugin/plugin.json
+++ b/plugins/devflow-review/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
   "agents": ["git", "reviewer", "synthesizer"],
   "skills": [
     "accessibility",
+    "agent-teams",
     "architecture-patterns",
     "complexity-patterns",
     "consistency-patterns",

--- a/shared/skills/agent-teams/SKILL.md
+++ b/shared/skills/agent-teams/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: agent-teams
+description: Agent Teams patterns for peer-to-peer agent collaboration, team spawning, debate protocols, and consensus formation
+user-invocable: false
+allowed-tools: Read, Grep, Glob
+---
+
+# Agent Teams Patterns
+
+Patterns for collaborative multi-agent workflows using Claude Code's Agent Teams feature. Teams enable peer-to-peer communication between agents, replacing one-way subagent reporting with adversarial debate and consensus.
+
+## Iron Law
+
+> **TEAMMATES CHALLENGE EACH OTHER**
+>
+> Every finding must survive peer scrutiny. No unchallenged claims reach the final
+> report. A single agent's opinion is a hypothesis; consensus from debate is a finding.
+
+---
+
+## When This Activates
+
+- Creating agent teams for review, implementation, or debugging
+- Spawning teammates with distinct perspectives
+- Coordinating multi-agent debate rounds
+- Forming consensus from conflicting findings
+
+## Core Patterns
+
+### Team Spawning
+
+Size team to task complexity. Assign distinct, non-overlapping perspectives.
+
+| Task Complexity | Team Size | Rationale |
+|----------------|-----------|-----------|
+| Simple review | 2-3 | Security + architecture sufficient |
+| Full review | 4-5 | Core perspectives covered |
+| Debug investigation | 3-5 | One per hypothesis |
+| Implementation | 2-4 | Domain-separated work units |
+
+Use `model: haiku` for validation-only teammates to control costs.
+
+### Challenge Protocol
+
+1. **Initial work**: Each teammate completes independent analysis
+2. **Exchange**: Lead broadcasts "Share findings and challenge others"
+3. **Direct debate**: Teammates message each other with evidence
+4. **Resolution**: Contradictions resolved through 1-2 exchanges
+5. **Escalation**: Unresolved after 2 exchanges → report disagreement to lead
+
+### Consensus Formation
+
+| Agreement Level | Confidence | Report As |
+|----------------|------------|-----------|
+| Unanimous | HIGH | Confirmed finding |
+| Majority (>50%) | MEDIUM | Finding with noted dissent |
+| Split (50/50) | LOW | Disagreement with both perspectives |
+
+### Team Cleanup
+
+Lead MUST always handle cleanup:
+1. Ensure all teammates have completed or been shut down
+2. Call cleanup to release resources
+3. Verify no orphaned sessions remain
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Correct Approach |
+|-------------|-----------------|
+| Overlapping perspectives | Assign distinct, non-overlapping focus areas |
+| Skipping debate round | Always require peer challenge before synthesis |
+| Unlimited debate | Cap at 2 exchanges per topic, then escalate |
+| Lead does analysis work | Lead coordinates only; teammates do analysis |
+| Ignoring minority opinion | Report dissent with evidence in final output |
+
+---
+
+## Extended References
+
+- `references/team-patterns.md` - Team structures for review, implement, debug workflows
+- `references/communication.md` - Message protocols, broadcast patterns, debate formats
+- `references/cleanup.md` - Session management, orphan detection, resource cleanup

--- a/shared/skills/agent-teams/references/cleanup.md
+++ b/shared/skills/agent-teams/references/cleanup.md
@@ -1,0 +1,71 @@
+# Session Management and Cleanup
+
+## Team Lifecycle
+
+```
+1. Lead creates team
+2. Lead spawns teammates
+3. Teammates work independently
+4. Debate rounds (teammates message directly)
+5. Lead collects consensus
+6. Lead shuts down teammates
+7. Lead calls cleanup
+8. Lead verifies no orphans
+```
+
+---
+
+## Cleanup Rules
+
+### Lead Responsibilities
+
+1. **Always call cleanup** - Even if team work was interrupted or errored
+2. **Shut down teammates first** - Before calling cleanup
+3. **Verify completion** - Check that no orphaned sessions remain
+
+### Error Handling
+
+If a teammate errors or hangs:
+1. Send shutdown message to the teammate
+2. Wait briefly for graceful shutdown
+3. Proceed with cleanup for remaining team
+4. Report the failed teammate in final output
+
+### Orphan Detection
+
+After cleanup, verify:
+- No tmux sessions from the team remain (split-pane mode)
+- No background processes from teammates
+- Team config at `~/.claude/teams/{team-name}/` is cleaned up
+
+---
+
+## Known Limitations
+
+| Limitation | Mitigation |
+|-----------|------------|
+| No session resumption for teammates | Start fresh; don't rely on teammate state persistence |
+| One team per session | Queue team work sequentially if needed |
+| Task status may lag | Use direct messages for time-sensitive coordination |
+| No nested teams | Teammates cannot spawn sub-teams; keep hierarchy flat |
+| Split-pane requires tmux/iTerm2 | Fall back to in-process mode if unavailable |
+
+---
+
+## Cost Management
+
+### Token Optimization
+
+| Strategy | Savings |
+|----------|---------|
+| Use haiku for validation teammates | ~70% per validation agent |
+| Limit debate to 2 rounds | Prevents runaway token usage |
+| Size teams to task (don't over-spawn) | Fewer agents = fewer tokens |
+| Shut down teammates promptly | No idle token consumption |
+
+### When NOT to Use Teams
+
+- Simple, single-focus tasks (use regular subagent)
+- Tasks requiring sequential dependency (no parallelism benefit)
+- Cost-sensitive operations where subagent is sufficient
+- Tasks where debate adds no value (e.g., formatting, simple fixes)

--- a/shared/skills/agent-teams/references/communication.md
+++ b/shared/skills/agent-teams/references/communication.md
@@ -1,0 +1,122 @@
+# Communication Protocols
+
+## Message Types
+
+### Direct Message (one-to-one)
+
+Use when challenging a specific teammate's finding:
+
+```
+To [Security Reviewer]:
+"Your finding about SQL injection at api/users.ts:42 - I disagree.
+The parameterized query at line 45 handles this. Check the query builder
+pattern used throughout this codebase."
+```
+
+### Broadcast (one-to-all)
+
+Use when sharing findings that affect all teammates:
+
+```
+Broadcast:
+"I found that the auth middleware is bypassed for /api/internal/* routes.
+This affects security, architecture, and testing perspectives."
+```
+
+---
+
+## Debate Protocol
+
+### Round Structure
+
+```
+Round 1: Initial findings (each teammate shares top findings)
+Round 2: Challenge round (teammates dispute or validate)
+Round 3: Resolution (update, withdraw, or escalate)
+```
+
+**Cap: 2 challenge exchanges per topic.** If unresolved, escalate to lead.
+
+### Challenge Format
+
+When challenging another teammate:
+
+```
+CHALLENGE to [Teammate]:
+- Finding: [what they claimed]
+- Evidence against: [your counter-evidence with file:line references]
+- Suggested resolution: [what you think is correct]
+```
+
+### Concession Format
+
+When accepting a challenge:
+
+```
+UPDATED based on [Teammate]'s challenge:
+- Original: [what I originally claimed]
+- Revised: [updated finding incorporating their evidence]
+```
+
+### Escalation Format
+
+When debate is unresolved after 2 exchanges:
+
+```
+ESCALATION to Lead:
+- Topic: [what we disagree about]
+- Position A: [first perspective with evidence]
+- Position B: [second perspective with evidence]
+- Recommendation: [which has stronger evidence, or "genuinely split"]
+```
+
+---
+
+## Lead Coordination Messages
+
+### Initiating Debate
+
+```
+Lead broadcast:
+"All teammates: Share your top 3-5 findings. After sharing, challenge
+any finding you disagree with. Provide evidence (file:line references).
+You have 2 exchange rounds to resolve disagreements."
+```
+
+### Ending Debate
+
+```
+Lead broadcast:
+"Debate round complete. Submit final findings with confidence levels:
+- HIGH: Unanimous or unchallenged with evidence
+- MEDIUM: Majority agreed, dissent noted
+- LOW: Split opinion, both perspectives included"
+```
+
+### Requesting Clarification
+
+```
+Lead to [Teammate]:
+"Your finding about X contradicts [Other Teammate]'s finding about Y.
+Can you address their evidence at [file:line]?"
+```
+
+---
+
+## Output Aggregation
+
+### Consensus Report Structure
+
+```markdown
+## Confirmed Findings (HIGH confidence)
+[Findings all teammates agreed on or that survived challenge]
+
+## Majority Findings (MEDIUM confidence)
+[Findings most agreed on, with dissenting view noted]
+
+## Split Findings (LOW confidence)
+[Genuinely contested findings with both perspectives and evidence]
+
+## Withdrawn Findings
+[Findings that were disproved during debate]
+```

--- a/shared/skills/agent-teams/references/team-patterns.md
+++ b/shared/skills/agent-teams/references/team-patterns.md
@@ -1,0 +1,109 @@
+# Team Patterns by Workflow
+
+## Review Team
+
+### Standard Review (4 perspectives)
+
+```
+Lead spawns:
+├── Security reviewer    → vulnerabilities, injection, auth, crypto
+├── Architecture reviewer → SOLID, coupling, layering, modularity
+├── Performance reviewer  → queries, algorithms, caching, I/O
+└── Quality reviewer      → complexity, tests, consistency, naming
+```
+
+### Extended Review (add conditionally)
+
+```
+Additional teammates based on changed files:
+├── TypeScript reviewer  → type safety, generics (if .ts/.tsx changed)
+├── React reviewer       → hooks, state, rendering (if .tsx/.jsx changed)
+├── Database reviewer    → schema, queries, migrations (if DB files changed)
+└── Dependencies reviewer → CVEs, versions, licenses (if package files changed)
+```
+
+### Review Debate Flow
+
+```
+1. Each reviewer analyzes independently
+2. Lead broadcasts: "Share top 3 findings and challenge others"
+3. Security challenges architecture: "This coupling creates attack surface"
+4. Architecture challenges performance: "Your caching suggestion breaks separation"
+5. Quality validates: "Tests don't cover the security concern raised"
+6. Lead collects consensus after max 2 exchange rounds
+```
+
+---
+
+## Implementation Team
+
+### Exploration Team (4 perspectives)
+
+```
+Lead spawns:
+├── Architecture explorer  → existing patterns, module structure
+├── Integration explorer   → entry points, services, config
+├── Reusable code explorer → utilities, helpers, shared logic
+└── Edge case explorer     → error conditions, boundaries, race conditions
+```
+
+### Planning Team (3 perspectives)
+
+```
+Lead spawns:
+├── Implementation planner → step-by-step coding approach
+├── Testing planner        → test strategy and coverage plan
+└── Risk planner           → potential issues, rollback strategy
+```
+
+### Implementation Debate
+
+```
+1. Explorers share findings
+2. Architecture challenges edge cases: "This boundary isn't handled"
+3. Integration challenges reusable code: "That helper doesn't cover our case"
+4. Lead synthesizes consensus exploration
+
+5. Planners propose approaches
+6. Testing challenges implementation: "This approach is untestable"
+7. Risk challenges both: "Rollback is impossible with this migration"
+8. Lead synthesizes consensus plan
+```
+
+---
+
+## Debug Team
+
+### Hypothesis Investigation (3-5 hypotheses)
+
+```
+Lead spawns (one per hypothesis):
+├── Hypothesis A investigator → state management / race condition
+├── Hypothesis B investigator → configuration / environment
+├── Hypothesis C investigator → edge case / input validation
+└── Hypothesis D investigator → dependency / version issue
+```
+
+### Debug Debate Flow
+
+```
+1. Each investigator gathers evidence for their hypothesis
+2. Lead broadcasts: "Present evidence. Disprove each other."
+3. Investigator A: "Found race condition at file:line"
+4. Investigator B: "My config theory is disproved by A's evidence"
+5. Investigator C: "A's race condition doesn't explain the timing"
+6. Converge on surviving hypothesis with strongest evidence
+```
+
+---
+
+## Team Size Guidelines
+
+| Scenario | Min | Max | Rationale |
+|----------|-----|-----|-----------|
+| Quick review | 2 | 3 | Focused, low cost |
+| Full review | 4 | 5 | Core perspectives |
+| Exploration | 3 | 4 | Diminishing returns beyond 4 |
+| Planning | 2 | 3 | Too many cooks |
+| Debugging | 3 | 5 | One per viable hypothesis |
+| Parallel coding | 2 | 3 | Merge complexity grows fast |

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -90,6 +90,13 @@ const DEVFLOW_PLUGINS: PluginDefinition[] = [
     skills: ['implementation-patterns', 'security-patterns'],
   },
   {
+    name: 'devflow-debug',
+    description: 'Debugging with competing hypotheses',
+    commands: ['/debug'],
+    agents: ['git'],
+    skills: ['agent-teams', 'git-safety'],
+  },
+  {
     name: 'devflow-self-review',
     description: 'Self-review workflow (Simplifier + Scrutinizer)',
     commands: ['/self-review'],

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -36,6 +36,11 @@ const DEVFLOW_PLUGINS: PluginDefinition[] = [
     commands: ['/resolve'],
   },
   {
+    name: 'devflow-debug',
+    description: 'Competing hypothesis debugging',
+    commands: ['/debug'],
+  },
+  {
     name: 'devflow-catch-up',
     description: 'Context restoration from status logs',
     commands: ['/catch-up'],

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -156,6 +156,7 @@ export const uninstallCommand = new Command('uninstall')
           'github-patterns',
           'implementation-patterns',
           'codebase-navigation',
+          'agent-teams',
           // Tier 2: Specialized Skills
           'test-design',
           'code-smell',
@@ -166,6 +167,8 @@ export const uninstallCommand = new Command('uninstall')
           // Tier 3: Domain-Specific Skills
           'typescript',
           'react',
+          'accessibility',
+          'frontend-design',
           // Review Pattern Skills (used by Reviewer agent)
           'architecture-patterns',
           'complexity-patterns',

--- a/src/templates/settings.json
+++ b/src/templates/settings.json
@@ -6,7 +6,8 @@
   },
   "env": {
     "ENABLE_TOOL_SEARCH": "true",
-    "ENABLE_LSP_TOOL": "true"
+    "ENABLE_LSP_TOOL": "true",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "extraKnownMarketplaces": {
     "devflow": {


### PR DESCRIPTION
## Summary

- Integrate Claude Code's Agent Teams feature across `/review`, `/implement`, and a new `/debug` command
- Enable peer-to-peer agent debate replacing one-way subagent reporting
- Add `agent-teams` foundation skill with team spawning, challenge protocol, and consensus patterns
- All commands gracefully fall back to parallel subagents when Agent Teams is unavailable

## Changes

### New Plugin: `devflow-debug`
- `/debug` command for competing hypothesis investigation
- Spawns 3-5 investigators, each pursuing a different theory
- Adversarial debate where agents disprove each other's hypotheses
- Root cause report with confidence levels

### Transformed: `/review`
- Reviewers now debate findings as teammates (Security, Architecture, Performance, Quality)
- Findings classified by consensus: HIGH / MEDIUM / LOW confidence
- Lead synthesizes consensus directly (Synthesizer agent no longer needed for this)

### Transformed: `/implement`
- Exploration phase uses agent team with debate round
- Planning phase uses agent team with debate round
- Phase 9 Shepherd↔Coder uses direct team dialogue instead of orchestrator-mediated loops

### Infrastructure
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json
- `agent-teams` skill added to review, implement, debug plugin manifests
- CLI: init.ts, list.ts, uninstall.ts updated for new plugin
- CLAUDE.md, README.md, CHANGELOG.md updated

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] `npx devflow-kit list` shows `/debug`
- [ ] `npx devflow-kit init` installs `agent-teams` skill
- [ ] `/review` falls back to subagents without Agent Teams enabled
- [ ] `/implement` falls back to subagents without Agent Teams enabled
- [ ] `/debug` spawns hypothesis team when Agent Teams available