### PR TITLE
feat: audit and expand Agent Teams across workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,10 @@ DevFlow is organized as a plugin marketplace with 9 self-contained plugins:
 2. **Shared Skills** (`shared/skills/`) - Single source of truth for all 28 skills
 3. **Shared Agents** (`shared/agents/`) - Single source of truth for 10 reusable agents
 4. **Plugins** (`plugins/`) - Self-contained packages with commands, agents, and skills
-   - `devflow-specify` - Feature specification workflow
+   - `devflow-specify` - Feature specification workflow (with Agent Teams)
    - `devflow-implement` - Complete task implementation lifecycle (with Agent Teams)
    - `devflow-review` - Comprehensive code review (with Agent Teams)
-   - `devflow-resolve` - Review issue resolution
+   - `devflow-resolve` - Review issue resolution (with Agent Teams)
    - `devflow-debug` - Competing hypothesis debugging (with Agent Teams)
    - `devflow-self-review` - Self-review workflow
    - `devflow-catch-up` - Context restoration

--- a/plugins/devflow-implement/commands/implement.md
+++ b/plugins/devflow-implement/commands/implement.md
@@ -92,7 +92,7 @@ Max 2 debate rounds, then submit consensus exploration findings.
 
 **Exploration team output**: Consensus findings on patterns, integration points, reusable code, edge cases.
 
-Shut down exploration team and clean up.
+Shut down exploration team and clean up. **CRITICAL**: Verify team cleanup completed (TeamDelete confirmed) before creating the planning team in Phase 4. One team per session — racing to create the next team before cleanup finishes will fail silently.
 
 ### Phase 3: Synthesize Exploration
 
@@ -153,7 +153,7 @@ Max 2 debate rounds, then submit consensus plan.
 - **HIGH**: 20-30 files, multiple modules → SEQUENTIAL_CODERS (2-3 phases)
 - **CRITICAL**: >30 files, cross-cutting concerns → SEQUENTIAL_CODERS (more phases)
 
-Shut down planning team and clean up.
+Shut down planning team and clean up. **CRITICAL**: Verify team cleanup completed (TeamDelete confirmed) before creating the alignment team in Phase 9. One team per session — racing to create the next team before cleanup finishes will fail silently.
 
 ### Phase 5: Synthesize Planning
 
@@ -374,7 +374,7 @@ Rules:
 4. Max 2 exchanges before escalating to lead
 ```
 
-After dialogue completes, shut down alignment team.
+After dialogue completes, shut down alignment team and verify cleanup (TeamDelete confirmed).
 
 **Without Agent Teams (fallback):**
 

--- a/plugins/devflow-resolve/.claude-plugin/plugin.json
+++ b/plugins/devflow-resolve/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
   "agents": ["git", "resolver", "simplifier"],
   "skills": [
     "implementation-patterns",
-    "security-patterns"
+    "security-patterns",
+    "agent-teams"
   ]
 }

--- a/plugins/devflow-specify/.claude-plugin/plugin.json
+++ b/plugins/devflow-specify/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "license": "MIT",
   "keywords": ["specification", "requirements", "planning", "issues", "github"],
   "agents": ["skimmer", "synthesizer"],
-  "skills": []
+  "skills": ["agent-teams"]
 }

--- a/shared/skills/agent-teams/references/team-patterns.md
+++ b/shared/skills/agent-teams/references/team-patterns.md
@@ -1,5 +1,28 @@
 # Team Patterns by Workflow
 
+## Task-Based Coordination
+
+All team workflows should use the shared task list for structured progress tracking:
+
+```
+1. Lead creates team
+2. Lead creates tasks (TaskCreate) for each teammate's work unit
+3. Lead spawns teammates, assigning tasks via TaskUpdate(owner)
+4. Teammates work, mark tasks completed via TaskUpdate(status: completed)
+5. Lead checks TaskList before proceeding to next phase
+6. Lead shuts down teammates, calls TeamDelete
+```
+
+**Example task creation for a review team:**
+
+```
+TaskCreate: "Security review of auth module" → assigned to Security Reviewer
+TaskCreate: "Architecture review of auth module" → assigned to Architecture Reviewer
+TaskCreate: "Performance review of auth module" → assigned to Performance Reviewer
+```
+
+---
+
 ## Review Team
 
 ### Standard Review (4 perspectives)
@@ -72,6 +95,88 @@ Lead spawns:
 
 ---
 
+## Specification Team
+
+### Requirements Exploration Team (4 perspectives)
+
+```
+Lead spawns:
+├── User Perspective Explorer  → target users, goals, pain points, user journeys
+├── Similar Features Explorer  → comparable features, scope patterns, precedents
+├── Constraints Explorer       → dependencies, business rules, security, performance
+└── Failure Mode Explorer      → error states, edge cases, validation needs
+```
+
+### Requirements Debate Flow
+
+```
+1. Each explorer shares findings from their perspective
+2. Constraints challenges user perspective: "This requirement conflicts with X constraint"
+3. Failure modes challenges similar features: "That pattern failed in Y scenario"
+4. Similar features validates user perspective: "This UX pattern works well in Z"
+5. Lead collects consensus after max 2 exchange rounds
+```
+
+### Scope Planning Team (3 perspectives)
+
+```
+Lead spawns:
+├── User Stories Planner       → actors, actions, outcomes ("As X, I want Y, so that Z")
+├── Scope Boundaries Planner   → v1 MVP, v2 deferred, out of scope, dependencies
+└── Acceptance Criteria Planner → success/failure/edge case criteria (testable)
+```
+
+### Scope Debate Flow
+
+```
+1. Each planner presents their analysis
+2. Scope challenges user stories: "This story is too broad for v1"
+3. Acceptance challenges scope: "These boundaries leave this edge case uncovered"
+4. User stories challenges acceptance: "This criterion is untestable"
+5. Lead collects consensus after max 2 exchange rounds
+```
+
+**Note**: Specification teams complement (not replace) the 3 mandatory clarification gates. User still drives all decisions via Gate 0, Gate 1, and Gate 2.
+
+---
+
+## Resolution Team
+
+### Cross-Validation Resolution Team
+
+```
+Lead spawns resolvers based on batches:
+├── Resolver A → Batch 1 issues (file-a cluster)
+├── Resolver B → Batch 2 issues (file-b cluster)
+└── Resolver C → Batch 3 issues (file-c cluster)
+```
+
+### Resolution Debate Flow
+
+```
+1. Each resolver independently validates + fixes their batch
+2. Lead broadcasts: "Review each other's fixes for cross-batch conflicts"
+3. Resolver A: "My fix in file-a.ts changes the interface that Resolver B depends on"
+4. Resolver B: "Confirmed — my fix in file-b.ts imports from that interface"
+5. Resolvers coordinate the fix or escalate conflict to lead
+6. Lead collects consensus after max 2 exchange rounds
+```
+
+### When Cross-Validation Adds Value
+
+- Fixes touch shared interfaces or types
+- Resolvers modify files that import from each other
+- Batch fixes could introduce conflicting patterns
+- Large resolution sets (>5 issues across multiple files)
+
+### When to Skip Cross-Validation
+
+- All fixes are in completely independent files
+- Only 1-2 batches with no shared dependencies
+- Fixes are trivial (typos, formatting, naming)
+
+---
+
 ## Debug Team
 
 ### Hypothesis Investigation (3-5 hypotheses)
@@ -105,5 +210,8 @@ Lead spawns (one per hypothesis):
 | Full review | 4 | 5 | Core perspectives |
 | Exploration | 3 | 4 | Diminishing returns beyond 4 |
 | Planning | 2 | 3 | Too many cooks |
+| Specification (explore) | 3 | 4 | Requirements need diverse perspectives |
+| Specification (scope) | 2 | 3 | Scope planning benefits from focus |
+| Resolution | 2 | 4 | One per independent batch |
 | Debugging | 3 | 5 | One per viable hypothesis |
 | Parallel coding | 2 | 3 | Merge complexity grows fast |

--- a/src/templates/settings.json
+++ b/src/templates/settings.json
@@ -4,6 +4,7 @@
     "type": "command",
     "command": "${DEVFLOW_DIR}/scripts/statusline.sh"
   },
+  "teammateMode": "auto",
   "env": {
     "ENABLE_TOOL_SEARCH": "true",
     "ENABLE_LSP_TOOL": "true",


### PR DESCRIPTION
## Summary

- Audited Agent Teams integration against [official docs](https://code.claude.com/docs/en/agent-teams) and fixed correctness issues
- Added one-team-per-session guards to `/implement` at all 3 team cleanup points (Phase 2, 4, 9)
- Expanded `agent-teams` skill with limitations table, detection/fallback pattern, and task list coordination
- Converted `/specify` exploration and planning phases from parallel subagents to Agent Teams with debate
- Converted `/resolve` from parallel resolvers to Agent Teams with cross-validation debate
- Added `teammateMode: auto` to settings template for split-pane teammate views

## Test plan

- [ ] `npm run build` succeeds with skills distributed to `devflow-specify` and `devflow-resolve`
- [ ] `node dist/cli.js init --override-settings` installs updated settings with `teammateMode`
- [ ] Verify `agent-teams` skill appears in `plugins/devflow-specify/skills/` and `plugins/devflow-resolve/skills/`
- [ ] Read `implement.md` — one-team guards present after Phase 2, 4, and 9 cleanup
- [ ] Read `specify.md` — team-based exploration (Phase 3) and planning (Phase 5) with fallback section
- [ ] Read `resolve.md` — team-based resolution (Phase 4) with cross-validation and fallback
- [ ] Read `SKILL.md` — has Limitations, Detection/Fallback, and Task List Coordination sections