### PR TITLE
fix: add hookEventName to SessionStart hook output

### DIFF
--- a/scripts/hooks/session-start-memory.sh
+++ b/scripts/hooks/session-start-memory.sh
@@ -78,6 +78,7 @@ fi
 # Output as additionalContext JSON envelope (Claude sees it as system context, not user-visible)
 jq -n --arg ctx "$CONTEXT" '{
   "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
     "additionalContext": $ctx
   }
 }'

--- a/src/templates/settings.json
+++ b/src/templates/settings.json
@@ -21,7 +21,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${DEVFLOW_DIR}/scripts/hooks/session-start-memory.sh"
+            "command": "${DEVFLOW_DIR}/scripts/hooks/session-start-memory.sh",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## Summary
- The SessionStart hook was silently failing because the shell script's JSON output was missing the required `hookEventName` field in `hookSpecificOutput`
- Added `hookEventName: "SessionStart"` to the jq output in `session-start-memory.sh`
- Added `timeout: 10` to the SessionStart hook config in the settings template for consistency with other hooks

## Test plan
- [x] Verified hook output includes `hookEventName` field
- [x] Tested `/clear` — hook fires successfully, working memory injected
- [x] Confirmed end-to-end: stop hook writes memory, session start hook restores it