### PR TITLE
fix(ambient): intent-first depth classification

### DIFF
--- a/plugins/devflow-ambient/README.md
+++ b/plugins/devflow-ambient/README.md
@@ -40,7 +40,7 @@ When enabled, a `UserPromptSubmit` hook injects a classification preamble before
 
 | Depth | When | Overhead |
 |-------|------|----------|
-| QUICK | Chat, exploration, < 20 words, no file refs | ~0 tokens |
+| QUICK | Chat, simple exploration, git/devops ops, single-word confirmations | ~0 tokens |
 | STANDARD | BUILD/DEBUG/REVIEW/PLAN, 1-5 file scope | ~500-1000 tokens (skill reads) |
 | ESCALATE | Multi-file, architectural, system-wide scope | ~0 extra tokens (nudge only) |
 

--- a/scripts/hooks/ambient-prompt.sh
+++ b/scripts/hooks/ambient-prompt.sh
@@ -24,9 +24,9 @@ if [[ "$PROMPT" == /* ]]; then
   exit 0
 fi
 
-# Skip short confirmations (< 3 words)
+# Skip single-word confirmations (< 2 words)
 WORD_COUNT=$(echo "$PROMPT" | wc -w | tr -d ' ')
-if [ "$WORD_COUNT" -lt 3 ]; then
+if [ "$WORD_COUNT" -lt 2 ]; then
   exit 0
 fi
 

--- a/shared/skills/ambient-router/SKILL.md
+++ b/shared/skills/ambient-router/SKILL.md
@@ -36,7 +36,7 @@ Determine what the user is trying to do from their prompt.
 | **EXPLORE** | "what is", "where is", "find", "show me", "explain", "how does" | "where is the config?", "explain this function" |
 | **CHAT** | greetings, meta-questions, confirmations, short responses | "thanks", "yes", "what can you do?" |
 
-**Ambiguous prompts:** Default to the lowest-overhead classification. "Update the README" → BUILD (but QUICK depth since it's a single file, simple edit).
+**Ambiguous prompts:** Default to the lowest-overhead classification. "Update the README" → BUILD/STANDARD. Git operations like "commit this" → QUICK.
 
 ## Step 2: Classify Depth
 
@@ -44,9 +44,9 @@ Determine how much enforcement the prompt warrants.
 
 | Depth | Criteria | Action |
 |-------|----------|--------|
-| **QUICK** | CHAT or EXPLORE intent, OR prompt < 20 words with no file references, OR single-file trivial edit | Respond normally. Zero overhead. Do not state classification. |
-| **STANDARD** | BUILD/DEBUG/REVIEW/PLAN intent with 1-5 file scope | Read and apply 2-3 relevant skills from the selection matrix below. State classification briefly. |
-| **ESCALATE** | Multi-file architectural change, "refactor all", system-wide scope, > 5 files | Respond at best effort + recommend: "This looks like it would benefit from `/implement` for full lifecycle management." |
+| **QUICK** | CHAT intent. EXPLORE with no analytical depth ("where is X?"). Git/devops operations (commit, push, merge, branch, pr, deploy, reinstall). Single-word continuations. | Respond normally. Zero overhead. Do not state classification. |
+| **STANDARD** | BUILD/DEBUG/REVIEW/PLAN intent (any word count). EXPLORE with analytical depth ("analyze our X", "discuss how Y works"). | Read and apply 2-3 relevant skills from the selection matrix below. State classification briefly. |
+| **ESCALATE** | Multi-file architectural change, system-wide scope, > 5 files. Detailed implementation plan (100+ words with plan structure). | Respond at best effort + recommend: "This looks like it would benefit from `/implement` for full lifecycle management." |
 
 ## Step 3: Select Skills (STANDARD depth only)
 


### PR DESCRIPTION
## Summary

- Remove the 20-word threshold that silently downgraded ~32% of BUILD/DEBUG prompts to QUICK depth (zero skill loading)
- Depth classification is now intent-first: BUILD/DEBUG/REVIEW/PLAN always get STANDARD depth regardless of word count
- QUICK depth reserved for CHAT, simple EXPLORE, git/devops operations, and single-word continuations
- Hook skip threshold lowered from < 3 words to < 2 (only single-word prompts like "yes" are skipped)

## Test plan

- [x] `npm run build` passes (26 skills, 9 plugins)
- [x] All 168 tests pass
- [ ] Manual: short BUILD prompts ("add CI", "fix the auth bug") should classify as BUILD/STANDARD
- [ ] Manual: git ops ("commit and push") should get QUICK (no classification output)
- [ ] Manual: single-word ("yes") skipped by hook entirely