### PR TITLE
feat(ambient): inject ambient-router skill at session start

### DIFF
--- a/scripts/hooks/ambient-prompt.sh
+++ b/scripts/hooks/ambient-prompt.sh
@@ -35,7 +35,7 @@ PREAMBLE="AMBIENT MODE ACTIVE: Before responding, silently classify this prompt:
 Intent: BUILD | DEBUG | REVIEW | PLAN | EXPLORE | CHAT
 Depth: QUICK (no overhead) | STANDARD (load skills) | ESCALATE (suggest /command)
 
-If STANDARD+: Read the ambient-router skill for classification details and skill selection matrix. For BUILD tasks, also load test-driven-development skill and enforce RED-GREEN-REFACTOR.
+If STANDARD+: Use the ambient-router skill already in your session context for classification details and skill selection matrix. For BUILD tasks, also load test-driven-development skill and enforce RED-GREEN-REFACTOR.
 
 If QUICK: Respond normally without stating classification.
 Only state classification aloud for STANDARD/ESCALATE."

--- a/scripts/hooks/session-start-memory.sh
+++ b/scripts/hooks/session-start-memory.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-# Working Memory: SessionStart Hook
-# Reads .memory/WORKING-MEMORY.md and injects it as additionalContext for the new session.
-# Also captures fresh git state so Claude knows what's changed since the memory was written.
-# Adds staleness warning if memory is >1 hour old.
+# SessionStart Hook
+# Injects working memory AND ambient skill content as additionalContext.
+# Memory: restores .memory/WORKING-MEMORY.md + patterns + git state + compact recovery.
+# Ambient: injects ambient-router SKILL.md so Claude has it in context (no Read call needed).
+# Either section can fire independently — ambient works even without memory files.
 
 set -euo pipefail
 
@@ -17,104 +18,128 @@ if [ -z "$CWD" ]; then
   exit 0
 fi
 
+CONTEXT=""
+
+# --- Section 1: Working Memory ---
+
 MEMORY_FILE="$CWD/.memory/WORKING-MEMORY.md"
 
-# No memory file = nothing to restore (fresh project or first session)
-if [ ! -f "$MEMORY_FILE" ]; then
-  exit 0
-fi
+if [ -f "$MEMORY_FILE" ]; then
+  MEMORY_CONTENT=$(cat "$MEMORY_FILE")
 
-MEMORY_CONTENT=$(cat "$MEMORY_FILE")
+  # Read accumulated patterns if they exist
+  PATTERNS_FILE="$CWD/.memory/PROJECT-PATTERNS.md"
+  PATTERNS_CONTENT=""
+  if [ -f "$PATTERNS_FILE" ]; then
+    PATTERNS_CONTENT=$(cat "$PATTERNS_FILE")
+  fi
 
-# Read accumulated patterns if they exist
-PATTERNS_FILE="$CWD/.memory/PROJECT-PATTERNS.md"
-PATTERNS_CONTENT=""
-if [ -f "$PATTERNS_FILE" ]; then
-  PATTERNS_CONTENT=$(cat "$PATTERNS_FILE")
-fi
+  # Compute staleness warning
+  if stat --version &>/dev/null 2>&1; then
+    FILE_MTIME=$(stat -c %Y "$MEMORY_FILE")
+  else
+    FILE_MTIME=$(stat -f %m "$MEMORY_FILE")
+  fi
+  NOW=$(date +%s)
+  AGE=$(( NOW - FILE_MTIME ))
 
-# Compute staleness warning
-if stat --version &>/dev/null 2>&1; then
-  FILE_MTIME=$(stat -c %Y "$MEMORY_FILE")
-else
-  FILE_MTIME=$(stat -f %m "$MEMORY_FILE")
-fi
-NOW=$(date +%s)
-AGE=$(( NOW - FILE_MTIME ))
-
-# Check for pre-compact memory snapshot (compaction recovery)
-BACKUP_FILE="$CWD/.memory/backup.json"
-COMPACT_NOTE=""
-if [ -f "$BACKUP_FILE" ]; then
-  BACKUP_MEMORY=$(jq -r '.memory_snapshot // ""' "$BACKUP_FILE" 2>/dev/null)
-  if [ -n "$BACKUP_MEMORY" ]; then
-    BACKUP_TS=$(jq -r '.timestamp // ""' "$BACKUP_FILE" 2>/dev/null)
-    BACKUP_EPOCH=0
-    if [ -n "$BACKUP_TS" ]; then
-      BACKUP_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$BACKUP_TS" +%s 2>/dev/null \
-        || date -d "$BACKUP_TS" +%s 2>/dev/null \
-        || echo "0")
-    fi
-    if [ "$BACKUP_EPOCH" -gt "$FILE_MTIME" ]; then
-      COMPACT_NOTE="
+  # Check for pre-compact memory snapshot (compaction recovery)
+  BACKUP_FILE="$CWD/.memory/backup.json"
+  COMPACT_NOTE=""
+  if [ -f "$BACKUP_FILE" ]; then
+    BACKUP_MEMORY=$(jq -r '.memory_snapshot // ""' "$BACKUP_FILE" 2>/dev/null)
+    if [ -n "$BACKUP_MEMORY" ]; then
+      BACKUP_TS=$(jq -r '.timestamp // ""' "$BACKUP_FILE" 2>/dev/null)
+      BACKUP_EPOCH=0
+      if [ -n "$BACKUP_TS" ]; then
+        BACKUP_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$BACKUP_TS" +%s 2>/dev/null \
+          || date -d "$BACKUP_TS" +%s 2>/dev/null \
+          || echo "0")
+      fi
+      if [ "$BACKUP_EPOCH" -gt "$FILE_MTIME" ]; then
+        COMPACT_NOTE="
 --- PRE-COMPACT SNAPSHOT ($BACKUP_TS) ---
 Context was compacted. This snapshot may contain decisions or progress not yet in working memory.
 
 $BACKUP_MEMORY
 "
+      fi
     fi
   fi
-fi
 
-STALE_WARNING=""
-if [ "$AGE" -gt 3600 ]; then
-  HOURS=$(( AGE / 3600 ))
-  STALE_WARNING="⚠ This working memory is ${HOURS}h old. Verify before relying on it.
+  STALE_WARNING=""
+  if [ "$AGE" -gt 3600 ]; then
+    HOURS=$(( AGE / 3600 ))
+    STALE_WARNING="⚠ This working memory is ${HOURS}h old. Verify before relying on it.
 
 "
-fi
+  fi
 
-# Capture fresh git state
-GIT_BRANCH=""
-GIT_STATUS=""
-GIT_LOG=""
+  # Capture fresh git state
+  GIT_BRANCH=""
+  GIT_STATUS=""
+  GIT_LOG=""
 
-if cd "$CWD" 2>/dev/null && git rev-parse --git-dir >/dev/null 2>&1; then
-  GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
-  GIT_STATUS=$(git status --porcelain 2>/dev/null | head -20)
-  GIT_LOG=$(git log --oneline -5 2>/dev/null || echo "")
-fi
+  if cd "$CWD" 2>/dev/null && git rev-parse --git-dir >/dev/null 2>&1; then
+    GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+    GIT_STATUS=$(git status --porcelain 2>/dev/null | head -20)
+    GIT_LOG=$(git log --oneline -5 2>/dev/null || echo "")
+  fi
 
-# Build context string
-CONTEXT="${STALE_WARNING}--- WORKING MEMORY (from previous session) ---
+  # Build memory context
+  CONTEXT="${STALE_WARNING}--- WORKING MEMORY (from previous session) ---
 
 ${MEMORY_CONTENT}"
 
-# Insert accumulated patterns between working memory and git state
-if [ -n "$PATTERNS_CONTENT" ]; then
-  CONTEXT="${CONTEXT}
+  # Insert accumulated patterns between working memory and git state
+  if [ -n "$PATTERNS_CONTENT" ]; then
+    CONTEXT="${CONTEXT}
 
 --- PROJECT PATTERNS (accumulated) ---
 
 ${PATTERNS_CONTENT}"
-fi
+  fi
 
-CONTEXT="${CONTEXT}
+  CONTEXT="${CONTEXT}
 
 --- CURRENT GIT STATE ---
 Branch: ${GIT_BRANCH}
 Recent commits:
 ${GIT_LOG}"
 
-if [ -n "$GIT_STATUS" ]; then
-  CONTEXT="${CONTEXT}
+  if [ -n "$GIT_STATUS" ]; then
+    CONTEXT="${CONTEXT}
 Uncommitted changes:
 ${GIT_STATUS}"
+  fi
+
+  if [ -n "$COMPACT_NOTE" ]; then
+    CONTEXT="${CONTEXT}
+${COMPACT_NOTE}"
+  fi
 fi
 
-if [ -n "$COMPACT_NOTE" ]; then
+# --- Section 2: Ambient Skill Injection ---
+
+# Inject ambient-router SKILL.md directly into context so Claude doesn't need a Read call.
+# Only injects when ambient mode is enabled (UserPromptSubmit hook present in settings).
+AMBIENT_SKILL_PATH="$HOME/.claude/skills/ambient-router/SKILL.md"
+[ ! -f "$AMBIENT_SKILL_PATH" ] && AMBIENT_SKILL_PATH="$CWD/.claude/skills/ambient-router/SKILL.md"
+
+SETTINGS_FILE="$HOME/.claude/settings.json"
+if [ -f "$AMBIENT_SKILL_PATH" ] && [ -f "$SETTINGS_FILE" ] && grep -q "ambient-prompt" "$SETTINGS_FILE" 2>/dev/null; then
+  AMBIENT_SKILL_CONTENT=$(cat "$AMBIENT_SKILL_PATH")
   CONTEXT="${CONTEXT}
-${COMPACT_NOTE}"
+
+--- AMBIENT ROUTER (auto-loaded) ---
+${AMBIENT_SKILL_CONTENT}"
+fi
+
+# --- Output ---
+
+# Only output if we have something to inject
+if [ -z "$CONTEXT" ]; then
+  exit 0
 fi
 
 # Output as additionalContext JSON envelope (Claude sees it as system context, not user-visible)


### PR DESCRIPTION
## Summary
- Restructures `session-start-memory.sh` to not early-exit when no memory file exists
- Injects `ambient-router/SKILL.md` content directly into session context at startup
- Updates `ambient-prompt.sh` preamble to reference "skill already in your session context" instead of requiring a Read tool call

## Problem
`ambient-prompt.sh` line 38 tells Claude to "Read the ambient-router skill" — this requires Claude to make a Read tool call, which it often skips, making ambient mode appear broken. Additionally, the session-start hook exits early if no `.memory/WORKING-MEMORY.md` exists, meaning ambient injection would never fire for projects without working memory.

## Fix
1. **Remove early exit**: Session-start hook now builds context incrementally — memory section (if exists) + ambient section (if enabled) — either can fire independently
2. **Direct injection**: Ambient router skill content is injected into `additionalContext` at session start, eliminating the need for a Read tool call
3. **Simplified preamble**: ambient-prompt.sh now references the skill "already in your session context"

## Test plan
- [x] `npm run build` passes (40 skill copies, 20 agent copies)
- [x] `npm test` — all 178 tests pass
- [x] With memory + ambient: context contains both memory and ambient router content
- [x] Without memory, with ambient: context still contains ambient router content (critical fix)
- [x] Without ambient: no ambient content injected

Closes #79
Part of #78