### PR TITLE
feat(skills): skill shadowing for personal overrides

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -9,6 +9,7 @@ import { uninstallCommand } from './commands/uninstall.js';
 import { listCommand } from './commands/list.js';
 import { ambientCommand } from './commands/ambient.js';
 import { memoryCommand } from './commands/memory.js';
+import { skillsCommand } from './commands/skills.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -33,6 +34,7 @@ program.addCommand(uninstallCommand);
 program.addCommand(listCommand);
 program.addCommand(ambientCommand);
 program.addCommand(memoryCommand);
+program.addCommand(skillsCommand);
 
 // Handle no command
 program.action(() => {

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1,0 +1,127 @@
+import { Command } from 'commander';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as p from '@clack/prompts';
+import color from 'picocolors';
+import { getClaudeDirectory, getDevFlowDirectory } from '../utils/paths.js';
+import { getAllSkillNames } from '../plugins.js';
+import { copyDirectory } from '../utils/installer.js';
+
+/**
+ * Check if a directory exists.
+ */
+async function dirExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the shadow directory for a skill.
+ */
+function getShadowDir(devflowDir: string, skillName: string): string {
+  return path.join(devflowDir, 'skills', skillName);
+}
+
+/**
+ * Check if a skill has a shadow (personal override).
+ */
+export async function hasShadow(skillName: string, devflowDir?: string): Promise<boolean> {
+  const dir = devflowDir ?? getDevFlowDirectory();
+  return dirExists(getShadowDir(dir, skillName));
+}
+
+/**
+ * List all shadowed skill names.
+ */
+export async function listShadowed(devflowDir?: string): Promise<string[]> {
+  const dir = devflowDir ?? getDevFlowDirectory();
+  const shadowsRoot = path.join(dir, 'skills');
+
+  try {
+    const entries = await fs.readdir(shadowsRoot, { withFileTypes: true });
+    return entries.filter(e => e.isDirectory()).map(e => e.name);
+  } catch {
+    return [];
+  }
+}
+
+export const skillsCommand = new Command('skills')
+  .description('Manage skill overrides (shadow/unshadow/list)')
+  .argument('<action>', 'Action: shadow, unshadow, or list-shadowed')
+  .argument('[name]', 'Skill name (required for shadow/unshadow)')
+  .action(async (action: string, name: string | undefined) => {
+    const devflowDir = getDevFlowDirectory();
+    const claudeDir = getClaudeDirectory();
+    const allSkills = getAllSkillNames();
+
+    if (action === 'shadow') {
+      if (!name) {
+        p.log.error('Skill name required. Usage: devflow skills shadow <name>');
+        p.log.info(`Available skills: ${allSkills.join(', ')}`);
+        process.exit(1);
+      }
+
+      if (!allSkills.includes(name)) {
+        p.log.error(`Unknown skill: ${name}`);
+        p.log.info(`Available skills: ${allSkills.join(', ')}`);
+        process.exit(1);
+      }
+
+      const installedSkillDir = path.join(claudeDir, 'skills', name);
+      if (!await dirExists(installedSkillDir)) {
+        p.log.error(`Skill not installed: ${name}. Run devflow init first.`);
+        process.exit(1);
+      }
+
+      const shadowDir = getShadowDir(devflowDir, name);
+      if (await dirExists(shadowDir)) {
+        p.log.info(`${name} is already shadowed`);
+        return;
+      }
+
+      // Create shadow directory and copy original as reference backup
+      await fs.mkdir(path.join(devflowDir, 'skills'), { recursive: true });
+      await copyDirectory(installedSkillDir, shadowDir);
+
+      p.log.success(`Shadowed ${color.cyan(name)}`);
+      p.log.info(`Edit ${color.dim(path.join(claudeDir, 'skills', name, 'SKILL.md'))} — it won't be overwritten on next init.`);
+    } else if (action === 'unshadow') {
+      if (!name) {
+        p.log.error('Skill name required. Usage: devflow skills unshadow <name>');
+        process.exit(1);
+      }
+
+      const shadowDir = getShadowDir(devflowDir, name);
+      if (!await dirExists(shadowDir)) {
+        p.log.info(`${name} is not shadowed`);
+        return;
+      }
+
+      await fs.rm(shadowDir, { recursive: true, force: true });
+
+      p.log.success(`Unshadowed ${color.cyan(name)}`);
+      p.log.info('Run devflow init to restore DevFlow\'s version.');
+    } else if (action === 'list-shadowed') {
+      const shadowed = await listShadowed(devflowDir);
+
+      if (shadowed.length === 0) {
+        p.log.info('No shadowed skills');
+        return;
+      }
+
+      p.log.info(`Shadowed skills (${shadowed.length}):`);
+      for (const skill of shadowed) {
+        const isKnown = allSkills.includes(skill);
+        const status = isKnown ? color.green('active') : color.yellow('unknown skill');
+        p.log.info(`  ${color.cyan(skill)} — ${status}`);
+      }
+    } else {
+      p.log.error(`Unknown action: ${action}`);
+      p.log.info('Usage: devflow skills <shadow|unshadow|list-shadowed> [name]');
+      process.exit(1);
+    }
+  });

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -11,6 +11,7 @@ import { isClaudeCliAvailable } from '../utils/cli.js';
 import { DEVFLOW_PLUGINS, getAllSkillNames, LEGACY_SKILL_NAMES, type PluginDefinition } from '../plugins.js';
 import { removeAmbientHook } from './ambient.js';
 import { removeMemoryHooks } from './memory.js';
+import { listShadowed } from './skills.js';
 import { detectShell, getProfilePath } from '../utils/safe-delete.js';
 import { isAlreadyInstalled, removeFromProfile } from '../utils/safe-delete-install.js';
 import { removeManagedSettings } from '../utils/post-install.js';
@@ -431,6 +432,15 @@ export const uninstallCommand = new Command('uninstall')
         } else {
           p.log.info(`Safe-delete function preserved in ${profilePath} (non-interactive mode)`);
         }
+      }
+    }
+
+    // Warn about personal skill overrides
+    if (!isSelectiveUninstall) {
+      const shadowed = await listShadowed();
+      if (shadowed.length > 0) {
+        p.log.warn(`Personal skill overrides remain in ~/.devflow/skills/: ${shadowed.join(', ')}`);
+        p.log.info(color.dim('Remove manually or run: rm -rf ~/.devflow/skills/'));
       }
     }
 

--- a/src/cli/utils/installer.ts
+++ b/src/cli/utils/installer.ts
@@ -149,6 +149,12 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<void
       }
     }
     for (const skill of allSkills) {
+      // Skip cleanup for shadowed skills — user has a personal override
+      const shadowDir = path.join(devflowDir, 'skills', skill);
+      try {
+        const stat = await fs.stat(shadowDir);
+        if (stat.isDirectory()) continue;
+      } catch { /* no shadow — proceed with cleanup */ }
       try {
         await fs.rm(path.join(claudeDir, 'skills', skill), { recursive: true, force: true });
       } catch { /* ignore */ }
@@ -200,13 +206,19 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<void
       }
     } catch { /* no agents directory */ }
 
-    // Install skills (deduplicated)
+    // Install skills (deduplicated, respects shadows)
     const skillsSource = path.join(pluginSourceDir, 'skills');
     try {
       const skillDirs = await fs.readdir(skillsSource, { withFileTypes: true });
       for (const skillDir of skillDirs) {
         if (skillDir.isDirectory()) {
           if (skillsMap.get(skillDir.name) === plugin.name) {
+            // Skip copy for shadowed skills — user has a personal override
+            const shadowDir = path.join(devflowDir, 'skills', skillDir.name);
+            try {
+              const stat = await fs.stat(shadowDir);
+              if (stat.isDirectory()) continue;
+            } catch { /* no shadow — proceed with copy */ }
             const skillTarget = path.join(claudeDir, 'skills', skillDir.name);
             await copyDirectory(
               path.join(skillsSource, skillDir.name),

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { hasShadow, listShadowed } from '../src/cli/commands/skills.js';
+
+describe('hasShadow', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns false when no shadow exists', async () => {
+    const result = await hasShadow('core-patterns', tmpDir);
+    expect(result).toBe(false);
+  });
+
+  it('returns true when shadow directory exists', async () => {
+    await fs.mkdir(path.join(tmpDir, 'skills', 'core-patterns'), { recursive: true });
+    const result = await hasShadow('core-patterns', tmpDir);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when shadow is a file not a directory', async () => {
+    await fs.mkdir(path.join(tmpDir, 'skills'), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, 'skills', 'core-patterns'), 'not a dir');
+    const result = await hasShadow('core-patterns', tmpDir);
+    expect(result).toBe(false);
+  });
+});
+
+describe('listShadowed', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty array when no shadows exist', async () => {
+    const result = await listShadowed(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when skills directory does not exist', async () => {
+    const result = await listShadowed(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('lists all shadowed skill directories', async () => {
+    await fs.mkdir(path.join(tmpDir, 'skills', 'core-patterns'), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, 'skills', 'test-patterns'), { recursive: true });
+
+    const result = await listShadowed(tmpDir);
+    expect(result).toHaveLength(2);
+    expect(result).toContain('core-patterns');
+    expect(result).toContain('test-patterns');
+  });
+
+  it('ignores files in skills directory (only lists directories)', async () => {
+    await fs.mkdir(path.join(tmpDir, 'skills', 'core-patterns'), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, 'skills'), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, 'skills', '.DS_Store'), '');
+
+    const result = await listShadowed(tmpDir);
+    expect(result).toEqual(['core-patterns']);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `devflow skills shadow <name>` — saves reference copy to `~/.devflow/skills/`, marks skill as user-managed
- Adds `devflow skills unshadow <name>` — removes override, next `devflow init` restores default
- Adds `devflow skills list-shadowed` — shows all overridden skills with active/unknown status
- Installer skips cleanup and copy for shadowed skills during `devflow init`
- Uninstall warns about remaining personal overrides

## How It Works
1. `devflow skills shadow core-patterns` → copies current version to `~/.devflow/skills/core-patterns/` as reference
2. User edits `~/.claude/skills/core-patterns/SKILL.md` freely
3. `devflow init` sees shadow → skips overwriting that skill
4. `devflow skills unshadow core-patterns` → removes shadow → next init restores default

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 185 tests pass (7 new)
- [x] `hasShadow` returns false when no shadow exists
- [x] `hasShadow` returns true when shadow directory exists
- [x] `listShadowed` returns empty array for fresh install
- [x] `listShadowed` lists all shadow directories, ignores files

Closes #81
Part of #78