### PR TITLE
chore: improve init prompts and document missing flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Init prompt improvements** — Agent Teams marked as experimental with recommendation to disable; ambient mode now defaults to enabled (recommended)
+- **Init flags documented** — Added `--ambient`/`--no-ambient` and `--memory`/`--no-memory` to README
+
 ---
 
 ## [1.3.1] - 2026-03-08

--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ Session context is saved and restored automatically via Working Memory hooks —
 |--------|-------------|
 | `--plugin <names>` | Comma-separated plugin names (e.g., `implement,code-review`) |
 | `--scope <user\|local>` | Installation scope (default: user) |
-| `--teams` / `--no-teams` | Enable/disable experimental Agent Teams (default: off) |
+| `--teams` / `--no-teams` | Enable/disable Agent Teams (experimental, default: off) |
+| `--ambient` / `--no-ambient` | Enable/disable ambient mode (default: on) |
+| `--memory` / `--no-memory` | Enable/disable working memory (default: on) |
 | `--verbose` | Show detailed output |
 
 ### Uninstall Options

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -200,15 +200,18 @@ export const initCommand = new Command('init')
     } else if (!process.stdin.isTTY) {
       teamsEnabled = false;
     } else {
-      const teamsChoice = await p.confirm({
-        message: 'Enable Agent Teams? (peer debate in review, exploration, debugging)',
-        initialValue: false,
+      const teamsChoice = await p.select({
+        message: 'Enable Agent Teams?',
+        options: [
+          { value: false, label: 'No (Recommended)', hint: 'Experimental — may be unstable' },
+          { value: true, label: 'Yes', hint: 'Advanced — peer debate in review, exploration, debugging' },
+        ],
       });
       if (p.isCancel(teamsChoice)) {
         p.cancel('Installation cancelled.');
         process.exit(0);
       }
-      teamsEnabled = teamsChoice;
+      teamsEnabled = teamsChoice as boolean;
     }
 
     // Ambient mode selection
@@ -216,20 +219,23 @@ export const initCommand = new Command('init')
     if (options.ambient !== undefined) {
       ambientEnabled = options.ambient;
     } else if (!process.stdin.isTTY) {
-      ambientEnabled = false;
+      ambientEnabled = true;
     } else {
-      const ambientChoice = await p.confirm({
-        message: 'Enable ambient mode? (auto-loads relevant skills based on each prompt)',
-        initialValue: false,
+      const ambientChoice = await p.select({
+        message: 'Enable ambient mode?',
+        options: [
+          { value: true, label: 'Yes (Recommended)', hint: 'Auto-loads relevant skills for each prompt' },
+          { value: false, label: 'No', hint: 'Full control — load skills manually' },
+        ],
       });
       if (p.isCancel(ambientChoice)) {
         p.cancel('Installation cancelled.');
         process.exit(0);
       }
-      ambientEnabled = ambientChoice;
+      ambientEnabled = ambientChoice as boolean;
     }
 
-    // Working memory selection (defaults ON — foundational, unlike ambient's false)
+    // Working memory selection (defaults ON — foundational feature)
     let memoryEnabled: boolean;
     if (options.memory !== undefined) {
       memoryEnabled = options.memory;


### PR DESCRIPTION
## Summary
- Agent Teams prompt now uses `p.select` with "No (Recommended)" default and "Experimental — may be unstable" hint
- Ambient mode prompt defaults to enabled (recommended) via `p.select`; non-TTY default changed from `false` to `true`
- Added `--ambient`/`--no-ambient` and `--memory`/`--no-memory` to README init flags table
- Added `[Unreleased]` changelog entry

## Test plan
- [x] `npm run build` passes
- [x] All 185 tests pass
- [ ] CI passes