### PR TITLE
fix: correct file detection and skill check in code-review

### DIFF
--- a/plugins/devflow-code-review/commands/code-review-teams.md
+++ b/plugins/devflow-code-review/commands/code-review-teams.md
@@ -38,9 +38,9 @@ Detect file types in diff to determine conditional reviews:
 
 | Condition | Adds Perspective |
 |-----------|-----------------|
-| .ts/.tsx files | typescript |
-| .tsx/.jsx files | react |
-| .tsx/.jsx files | accessibility |
+| Any .ts or .tsx files | typescript |
+| .tsx or .jsx files (React components) | react |
+| .tsx or .jsx files (React components) | accessibility |
 | .tsx/.jsx/.css/.scss files | frontend-design |
 | .go files | go |
 | .java files | java |
@@ -50,7 +50,7 @@ Detect file types in diff to determine conditional reviews:
 | Dependency files changed | dependencies |
 | Docs or significant code | documentation |
 
-**Skill availability check**: Language/ecosystem reviews (typescript, react, accessibility, frontend-design, go, java, python, rust) require their optional skill plugin to be installed. Before adding a conditional perspective, check if `~/.claude/skills/{focus}/SKILL.md` exists (use Glob). If the skill file doesn't exist, **skip that perspective** — the language plugin isn't installed. Non-language reviews (database, dependencies, documentation) use skills bundled with this plugin and are always available.
+**Skill availability check**: Language/ecosystem reviews (typescript, react, accessibility, frontend-design, go, java, python, rust) require their optional skill plugin to be installed. Before adding a conditional perspective, use Read to check if `~/.claude/skills/{focus}/SKILL.md` exists. If Read returns an error (file not found), **skip that perspective** — the language plugin isn't installed. Non-language reviews (database, dependencies, documentation) use skills bundled with this plugin and are always available.
 
 ### Phase 2: Spawn Review Team
 

--- a/plugins/devflow-code-review/commands/code-review.md
+++ b/plugins/devflow-code-review/commands/code-review.md
@@ -38,9 +38,9 @@ Detect file types in diff to determine conditional reviews:
 
 | Condition | Adds Review |
 |-----------|-------------|
-| .ts/.tsx files | typescript |
-| .tsx/.jsx files | react |
-| .tsx/.jsx files | accessibility |
+| Any .ts or .tsx files | typescript |
+| .tsx or .jsx files (React components) | react |
+| .tsx or .jsx files (React components) | accessibility |
 | .tsx/.jsx/.css/.scss files | frontend-design |
 | .go files | go |
 | .java files | java |
@@ -50,7 +50,7 @@ Detect file types in diff to determine conditional reviews:
 | Dependency files changed | dependencies |
 | Docs or significant code | documentation |
 
-**Skill availability check**: Language/ecosystem reviews (typescript, react, accessibility, frontend-design, go, java, python, rust) require their optional skill plugin to be installed. Before spawning a conditional Reviewer for these focuses, check if `~/.claude/skills/{focus}/SKILL.md` exists (use Glob). If the skill file doesn't exist, **skip that review** — the language plugin isn't installed. Non-language reviews (database, dependencies, documentation) use skills bundled with this plugin and are always available.
+**Skill availability check**: Language/ecosystem reviews (typescript, react, accessibility, frontend-design, go, java, python, rust) require their optional skill plugin to be installed. Before spawning a conditional Reviewer for these focuses, use Read to check if `~/.claude/skills/{focus}/SKILL.md` exists. If Read returns an error (file not found), **skip that review** — the language plugin isn't installed. Non-language reviews (database, dependencies, documentation) use skills bundled with this plugin and are always available.
 
 ### Phase 2: Run Reviews (Parallel)
 


### PR DESCRIPTION
## Summary
- Disambiguate TypeScript vs React file extension conditions in Phase 1 tables — `.ts/.tsx` was too similar to `.tsx/.jsx`, causing the orchestrating LLM to conflate them and miss plain `.ts` files
- Switch skill availability check from Glob to Read — Glob doesn't expand `~` to the home directory, causing all optional language skills to incorrectly report as "not installed"

## Root Cause
Two independent bugs combined:
1. **Extension conflation**: The condition table listed `.ts/.tsx` (TypeScript) adjacent to `.tsx/.jsx` (React). The orchestrating agent misread the TypeScript condition as `.tsx/.jsx`, skipping TypeScript review when only plain `.ts` files changed.
2. **Glob tilde bug**: `Glob("~/.claude/skills/{focus}/SKILL.md")` returns no results because Glob doesn't expand `~`. The `Read` tool does expand `~`, so switching to Read fixes skill detection on all platforms.

## Test plan
- [ ] Run `/code-review` on a branch with only `.ts` file changes — TypeScript review should trigger
- [ ] Run `/code-review` on a branch with `.tsx` changes — both TypeScript and React reviews should trigger
- [ ] Verify optional language skills (go, python, java, rust) are detected when installed