### PR TITLE
feat: smart branch naming for /implement

### DIFF
--- a/plugins/devflow-implement/commands/implement-teams.md
+++ b/plugins/devflow-implement/commands/implement-teams.md
@@ -27,21 +27,20 @@ Orchestrate a single task from exploration through implementation by spawning sp
 
 Record the current branch name as `BASE_BRANCH` - this will be the PR target.
 
-Generate a unique `TASK_ID`: `task-{YYYY-MM-DD_HHMM}` (e.g., `task-2025-01-15_1430`).
-
-Spawn Git agent to set up task environment:
+Spawn Git agent to set up task environment. The Git agent derives the branch name automatically from the issue or task description:
 
 ```
 Task(subagent_type="Git"):
 "OPERATION: setup-task
-TASK_ID: {task-id}
 BASE_BRANCH: {current branch name}
-ISSUE_INPUT: {issue number if provided, otherwise omit}
-Create feature branch and fetch issue if specified.
+ISSUE_INPUT: {issue number if $ARGUMENTS starts with #, otherwise omit}
+TASK_DESCRIPTION: {task description from $ARGUMENTS if not an issue number, otherwise omit}
+Derive branch name from issue or description, create feature branch, and fetch issue if specified.
 Return the branch setup summary."
 ```
 
 **Capture from Git agent output** (used throughout flow):
+- `TASK_ID`: The branch name created by Git agent (use as TASK_ID for rest of flow)
 - `BASE_BRANCH`: Branch this feature was created from (for PR target)
 - `ISSUE_NUMBER`: GitHub issue number (if provided)
 - `ISSUE_CONTENT`: Full issue body including description (if provided)

--- a/plugins/devflow-implement/commands/implement.md
+++ b/plugins/devflow-implement/commands/implement.md
@@ -27,21 +27,20 @@ Orchestrate a single task from exploration through implementation by spawning sp
 
 Record the current branch name as `BASE_BRANCH` - this will be the PR target.
 
-Generate a unique `TASK_ID`: `task-{YYYY-MM-DD_HHMM}` (e.g., `task-2025-01-15_1430`).
-
-Spawn Git agent to set up task environment:
+Spawn Git agent to set up task environment. The Git agent derives the branch name automatically from the issue or task description:
 
 ```
 Task(subagent_type="Git"):
 "OPERATION: setup-task
-TASK_ID: {task-id}
 BASE_BRANCH: {current branch name}
-ISSUE_INPUT: {issue number if provided, otherwise omit}
-Create feature branch and fetch issue if specified.
+ISSUE_INPUT: {issue number if $ARGUMENTS starts with #, otherwise omit}
+TASK_DESCRIPTION: {task description from $ARGUMENTS if not an issue number, otherwise omit}
+Derive branch name from issue or description, create feature branch, and fetch issue if specified.
 Return the branch setup summary."
 ```
 
 **Capture from Git agent output** (used throughout flow):
+- `TASK_ID`: The branch name created by Git agent (use as TASK_ID for rest of flow)
 - `BASE_BRANCH`: Branch this feature was created from (for PR target)
 - `ISSUE_NUMBER`: GitHub issue number (if provided)
 - `ISSUE_CONTENT`: Full issue body including description (if provided)

--- a/shared/agents/git.md
+++ b/shared/agents/git.md
@@ -21,7 +21,7 @@ The orchestrator provides:
 |-----------|---------|----------------|
 | `ensure-pr-ready` | Pre-flight for /review: commit, push, create PR | - |
 | `validate-branch` | Pre-flight for /resolve: check branch state | - |
-| `setup-task` | Create feature branch and fetch issue | `TASK_ID`, `BASE_BRANCH`, `ISSUE_INPUT` (optional) |
+| `setup-task` | Create feature branch and fetch issue | `BASE_BRANCH`, `ISSUE_INPUT` (optional), `TASK_DESCRIPTION` (optional) |
 | `fetch-issue` | Fetch GitHub issue for implementation | `ISSUE_INPUT` (number or search term) |
 | `comment-pr` | Create PR inline comments for review findings | `PR_NUMBER`, `REVIEW_BASE_DIR`, `TIMESTAMP` |
 | `manage-debt` | Update tech debt backlog with pre-existing issues | `REVIEW_DIR`, `TIMESTAMP` |
@@ -101,25 +101,30 @@ Pre-flight validation for `/resolve`. Checks branch state without modifications.
 
 ## Operation: setup-task
 
-Set up task environment: create feature branch and optionally fetch issue.
+Set up task environment: derive branch name, create feature branch, and optionally fetch issue.
 
 **Input:**
-- `TASK_ID`: Unique task identifier (becomes branch name)
 - `BASE_BRANCH`: Branch to create from (track this for PR target)
 - `ISSUE_INPUT` (optional): Issue number to fetch
+- `TASK_DESCRIPTION` (optional): Free-text task description (when no issue)
 
 **Process:**
 1. Record current branch as BASE_BRANCH for later PR targeting
-2. Create and checkout feature branch: `git checkout -b {TASK_ID}`
-3. If ISSUE_INPUT provided, fetch issue details via GitHub API
-4. Return setup summary with BASE_BRANCH recorded
+2. **Derive branch name:**
+   - If `ISSUE_INPUT` provided: fetch issue via GitHub API first, then derive branch name as `{type}/{number}-{slug}` where:
+     - `type` is inferred from issue labels: `bug` → `fix`, `documentation` or `docs` → `docs`, `refactor` → `refactor`, `chore` or `maintenance` → `chore`, default → `feature`
+     - `slug` is the issue title: lowercased, non-alphanumeric replaced with hyphens, consecutive hyphens collapsed, trimmed, max 40 characters
+   - If `TASK_DESCRIPTION` provided (no issue): infer type from description keywords (e.g., "fix login bug" → `fix`, "refactor auth" → `refactor`, "add JWT" → `feature`, "update docs" → `docs`, "chore: cleanup" → `chore`), then slugify description as `{type}/{slug}` (max 40 chars)
+   - If neither: fallback to `task-{YYYY-MM-DD_HHMM}`
+3. Create and checkout feature branch: `git checkout -b {derived-branch-name}`
+4. Return setup summary with branch name and BASE_BRANCH recorded
 
 **Output:**
 ```markdown
-## Task Setup: {TASK_ID}
+## Task Setup: {branch-name}
 
 ### Branch
-- **Feature branch**: {TASK_ID}
+- **Branch name**: {derived-branch-name}
 - **Base branch**: {BASE_BRANCH} (PR target)
 
 ### Issue (if fetched)


### PR DESCRIPTION
## Summary

- Moves branch name derivation into the Git agent's `setup-task` operation, so `/implement #42` automatically creates `feature/42-add-jwt-auth` instead of `task-2025-01-15_1430`
- Issue input derives `{type}/{number}-{slug}` from labels and title (bug→fix, docs→docs, refactor→refactor, default→feature)
- Free-text input infers type from keywords and slugifies as `{type}/{slug}`
- Falls back to `task-{YYYY-MM-DD_HHMM}` when neither issue nor description is provided
- Removes `TASK_ID` generation from both `implement.md` and `implement-teams.md` — the Git agent now owns and returns the branch name

## Test plan

- [ ] Run `npm run build` — verify clean build with agent distributed to plugins
- [ ] `/implement #<issue-with-bug-label>` — verify branch: `fix/{number}-{slug}`
- [ ] `/implement #<issue-no-labels>` — verify branch: `feature/{number}-{slug}`
- [ ] `/implement add JWT auth` — verify branch: `feature/add-jwt-auth`
- [ ] `/implement fix login bug` — verify branch: `fix/login-bug`
- [ ] `/implement` (conversation context only) — verify fallback: `task-{timestamp}`