### PR TITLE
feat: unconditional branch orientation in Coder agent

### DIFF
--- a/plugins/devflow-implement/commands/implement-teams.md
+++ b/plugins/devflow-implement/commands/implement-teams.md
@@ -318,11 +318,7 @@ FILES_FROM_PRIOR_PHASE: {list of files created}
 HANDOFF_REQUIRED: {true if not last phase}"
 ```
 
-**Handoff Protocol**: Each sequential Coder receives the prior Coder's implementation summary. The receiving Coder MUST:
-1. Check git log to see commits from previous phases
-2. Read actual files created - do not trust summary alone
-3. Identify patterns from actual code (naming, error handling, testing)
-4. Reference handoff summary to validate understanding
+**Handoff Protocol**: Each sequential Coder receives the prior Coder's implementation summary via PRIOR_PHASE_SUMMARY and FILES_FROM_PRIOR_PHASE. The Coder's built-in branch orientation step handles git log scanning, file reading, and pattern discovery automatically.
 
 ---
 

--- a/plugins/devflow-implement/commands/implement.md
+++ b/plugins/devflow-implement/commands/implement.md
@@ -191,11 +191,7 @@ FILES_FROM_PRIOR_PHASE: {list of files created}
 HANDOFF_REQUIRED: {true if not last phase}"
 ```
 
-**Handoff Protocol**: Each sequential Coder receives the prior Coder's implementation summary. The receiving Coder MUST:
-1. Check git log to see commits from previous phases
-2. Read actual files created - do not trust summary alone
-3. Identify patterns from actual code (naming, error handling, testing)
-4. Reference handoff summary to validate understanding
+**Handoff Protocol**: Each sequential Coder receives the prior Coder's implementation summary via PRIOR_PHASE_SUMMARY and FILES_FROM_PRIOR_PHASE. The Coder's built-in branch orientation step handles git log scanning, file reading, and pattern discovery automatically.
 
 ---
 

--- a/shared/agents/coder.md
+++ b/shared/agents/coder.md
@@ -29,11 +29,14 @@ You receive from orchestrator:
 
 ## Responsibilities
 
-1. **Orient on branch state**: Check git log for commits from previous Coders (if sequential). Read files created by prior phases - **do not trust summaries alone**. Identify patterns from actual code: naming conventions, error handling approach, testing style.
+1. **Orient on branch state** (always, before any implementation):
+   - Run `git log --oneline --stat -n 10` to scan recent commit history on this branch
+   - Run `git status` and `git diff --stat` and `git diff --cached --stat` to see uncommitted/unstaged work
+   - Cross-reference changed files against EXECUTION_PLAN to identify what's relevant to your task
+   - Read those relevant files to understand interfaces, types, naming conventions, error handling, and testing patterns established by prior work
+   - If PRIOR_PHASE_SUMMARY is provided, use it to validate your understanding — actual code is authoritative, summaries are supplementary
 
-2. **Reference handoff** (if PRIOR_PHASE_SUMMARY provided): Use summary to validate your understanding of prior work, not as the sole source of truth. The actual code is authoritative.
-
-3. **Load domain skills**: Based on DOMAIN hint and files in scope, dynamically load relevant language/ecosystem skills by reading their SKILL.md. Only load skills that are installed:
+2. **Load domain skills**: Based on DOMAIN hint and files in scope, dynamically load relevant language/ecosystem skills by reading their SKILL.md. Only load skills that are installed:
    - `backend` (TypeScript): Read `~/.claude/skills/typescript/SKILL.md`, `~/.claude/skills/input-validation/SKILL.md`
    - `backend` (Go): Read `~/.claude/skills/go/SKILL.md`
    - `backend` (Java): Read `~/.claude/skills/java/SKILL.md`
@@ -44,22 +47,22 @@ You receive from orchestrator:
    - `fullstack`: Combine backend + frontend skills
    - If a Read fails (skill not installed), skip it silently and continue.
 
-4. **Implement the plan**: Work through execution steps systematically, creating and modifying files. Follow existing patterns. Type everything. Use Result types if codebase uses them.
+3. **Implement the plan**: Work through execution steps systematically, creating and modifying files. Follow existing patterns. Type everything. Use Result types if codebase uses them.
 
-5. **Write tests**: Add tests for new functionality. Cover happy path, error cases, and edge cases. Follow existing test patterns.
+4. **Write tests**: Add tests for new functionality. Cover happy path, error cases, and edge cases. Follow existing test patterns.
 
-6. **Run tests**: Execute the test suite. Fix any failures. All tests must pass before proceeding.
+5. **Run tests**: Execute the test suite. Fix any failures. All tests must pass before proceeding.
 
-7. **Commit and push**: Create atomic commits with clear messages. Reference TASK_ID. Push to remote.
+6. **Commit and push**: Create atomic commits with clear messages. Reference TASK_ID. Push to remote.
 
-8. **Create PR** (if CREATE_PR=true): Create pull request against BASE_BRANCH with summary and testing notes.
+7. **Create PR** (if CREATE_PR=true): Create pull request against BASE_BRANCH with summary and testing notes.
 
-9. **Generate handoff** (if HANDOFF_REQUIRED=true): Include implementation summary for next Coder (see Output section).
+8. **Generate handoff** (if HANDOFF_REQUIRED=true): Include implementation summary for next Coder (see Output section).
 
 ## Principles
 
 1. **Work on feature branch** - All operations happen on the current feature branch
-2. **Branch orientation first** - In sequential execution, read actual files before trusting handoff summaries
+2. **Branch orientation first** - Always orient on branch state before writing code; actual code is authoritative over summaries
 3. **Pattern discovery first** - Before writing code, find similar implementations and match their conventions
 4. **Be decisive** - Make confident implementation choices. Don't present alternatives or ask permission for tactical decisions
 5. **Follow existing patterns** - Match codebase style, don't invent new conventions
@@ -124,4 +127,4 @@ Return structured completion status:
 - Switch branches during implementation
 - Push to branches other than your feature branch
 - Merge PRs (orchestrator handles this)
-- Trust handoff summaries without reading actual code (in sequential execution)
+- Trust handoff summaries without reading actual code


### PR DESCRIPTION
## Summary

- Make the Coder agent's orientation step unconditional — it now always runs `git log`, `git status`, `git diff --stat`, and `git diff --cached --stat` before writing any code, regardless of whether it's in a sequential chain
- Cross-references changed files against the execution plan and reads relevant files to understand established interfaces, types, naming conventions, error handling, and testing patterns
- Handoff summaries (PRIOR_PHASE_SUMMARY) become supplementary validation rather than the primary source of truth
- Simplify Handoff Protocol in both `implement.md` and `implement-teams.md` to defer to the Coder's built-in orientation instead of duplicating instructions

## Motivation

Previously, the Coder only checked prior work "if sequential" and didn't inspect uncommitted/unstaged changes. A single Coder on a branch with existing work (from validation-fix loops, prior developers, or partial implementation) would start implementing blind. Now orientation is unconditional and branching-model agnostic (last N commits, not BASE_BRANCH..HEAD).

## Test plan

- [x] `npm run build` passes — updated `coder.md` distributed to all plugins
- [ ] Manual: invoke `/implement` on a branch with existing commits, verify Coder runs git log/status/diff before coding
- [ ] No TypeScript tests affected (markdown-only changes)