### PR TITLE
fix: metadata and documentation accuracy — 5 quick wins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ DevFlow enhances Claude Code with intelligent development workflows. Modificatio
 
 ## Architecture Overview
 
-Plugin marketplace with 17 plugins (9 core + 8 optional language/ecosystem), each following the Claude plugins format (`.claude-plugin/plugin.json`, `commands/`, `agents/`, `skills/`).
+Plugin marketplace with 17 plugins (8 core + 9 optional language/ecosystem), each following the Claude plugins format (`.claude-plugin/plugin.json`, `commands/`, `agents/`, `skills/`).
 
 | Plugin | Purpose | Teams Variant |
 |--------|---------|---------------|
@@ -46,7 +46,7 @@ Commands with Teams Variant ship as `{name}.md` (parallel subagents) and `{name}
 devflow/
 ├── shared/skills/          # 32 skills (single source of truth)
 ├── shared/agents/          # 10 shared agents (single source of truth)
-├── plugins/devflow-*/      # 17 plugins (9 core + 8 optional language/ecosystem)
+├── plugins/devflow-*/      # 17 plugins (8 core + 9 optional language/ecosystem)
 ├── docs/reference/         # Detailed reference documentation
 ├── scripts/                # Helper scripts (statusline, docs-helpers)
 │   └── hooks/              # Working Memory + ambient hooks (stop, session-start, pre-compact, ambient-prompt)

--- a/docs/reference/skills-architecture.md
+++ b/docs/reference/skills-architecture.md
@@ -21,6 +21,7 @@ Shared patterns used by multiple agents.
 | `github-patterns` | GitHub API patterns (rate limiting, PR comments, issues, releases) | Git |
 | `implementation-patterns` | CRUD, API endpoints, events, config, logging | Coder, Resolver |
 | `agent-teams` | Agent Teams patterns for peer-to-peer collaboration, debate, consensus | /code-review, /implement, /debug |
+| `ambient-router` | Intent classification and proportional skill loading for ambient mode | `/ambient` command |
 | `knowledge-persistence` | Record/load architectural decisions and pitfalls to `.memory/knowledge/` | /implement, /code-review, /resolve, /debug, /specify, /self-review |
 
 ### Tier 1b: Pattern Skills
@@ -47,6 +48,8 @@ Listed in Claude Code's skill catalog. May auto-invoke based on description matc
 | Skill | Purpose | Agent Refs |
 |-------|---------|------------|
 | `input-validation` | Boundary validation enforcement | Coder |
+| `search-first` | Research-before-building enforcement for utility code | Coder |
+| `test-driven-development` | RED-GREEN-REFACTOR cycle enforcement | Coder |
 
 ### Tier 3: Domain-Specific Skills
 

--- a/plugins/devflow-audit-claude/commands/audit-claude.md
+++ b/plugins/devflow-audit-claude/commands/audit-claude.md
@@ -1,3 +1,7 @@
+---
+description: Audit CLAUDE.md files against Anthropic best practices
+---
+
 # Command: /audit-claude
 
 ## Description

--- a/plugins/devflow-debug/commands/debug.md
+++ b/plugins/devflow-debug/commands/debug.md
@@ -91,7 +91,7 @@ Focus area: {specific code area, mechanism, or condition}
 Once all investigators return, spawn a Synthesizer agent to aggregate findings:
 
 ```
-Task(subagent_type="general-purpose", name="synthesizer"):
+Task(subagent_type="Synthesizer"):
 "You are a root cause analyst. Synthesize these investigation reports:
 
 {paste all investigator reports}

--- a/shared/agents/simplifier.md
+++ b/shared/agents/simplifier.md
@@ -1,6 +1,7 @@
 ---
 name: Simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
+skills: core-patterns
 model: inherit
 ---
 

--- a/shared/agents/skimmer.md
+++ b/shared/agents/skimmer.md
@@ -1,6 +1,7 @@
 ---
 name: Skimmer
 description: Codebase orientation using skim to identify relevant files, functions, and patterns for a feature or task
+skills: knowledge-persistence
 model: inherit
 ---
 


### PR DESCRIPTION
## Summary

Five mechanical fixes from code review — metadata, frontmatter, and documentation accuracy only. No behavioral changes.

- **H3**: Add missing YAML frontmatter to `audit-claude.md` command
- **H4**: Fix `subagent_type` from `"general-purpose"` to `"Synthesizer"` in `debug.md`
- **H6**: Correct plugin count from "9 core + 8 optional" to "8 core + 9 optional" in CLAUDE.md (2 locations)
- **M2**: Add `skills:` frontmatter to Skimmer (`knowledge-persistence`) and Simplifier (`core-patterns`) agents
- **M8**: Catalog 3 missing skills (`ambient-router`, `search-first`, `test-driven-development`) in `skills-architecture.md`

## Verification

- `npm run build` passes (45 skill copies, 20 agent copies, 17 plugins)
- `npm test` passes (250/250 tests)
- `grep -r "general-purpose" plugins/` → 0 hits
- `grep "9 core" CLAUDE.md` → 0 hits

## Test plan

- [x] Build passes
- [x] All 250 tests pass
- [x] No behavioral changes — metadata/docs only