### PR TITLE
fix(init): hide ambient plugin from multiselect

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -168,7 +168,7 @@ export const initCommand = new Command('init')
       }
     } else if (process.stdin.isTTY) {
       const choices = DEVFLOW_PLUGINS
-        .filter(pl => pl.name !== 'devflow-core-skills')
+        .filter(pl => pl.name !== 'devflow-core-skills' && pl.name !== 'devflow-ambient')
         .map(pl => ({
           value: pl.name,
           label: pl.name.replace('devflow-', ''),
@@ -176,7 +176,7 @@ export const initCommand = new Command('init')
         }));
 
       const preSelected = DEVFLOW_PLUGINS
-        .filter(pl => !pl.optional && pl.name !== 'devflow-core-skills')
+        .filter(pl => !pl.optional && pl.name !== 'devflow-core-skills' && pl.name !== 'devflow-ambient')
         .map(pl => pl.name);
 
       const pluginSelection = await p.multiselect({
@@ -338,6 +338,11 @@ export const initCommand = new Command('init')
     const coreSkillsPlugin = DEVFLOW_PLUGINS.find(p => p.name === 'devflow-core-skills');
     if (pluginsToInstall.length > 0 && coreSkillsPlugin && !pluginsToInstall.includes(coreSkillsPlugin)) {
       pluginsToInstall = [coreSkillsPlugin, ...pluginsToInstall];
+    }
+
+    const ambientPlugin = DEVFLOW_PLUGINS.find(p => p.name === 'devflow-ambient');
+    if (ambientEnabled && ambientPlugin && !pluginsToInstall.includes(ambientPlugin)) {
+      pluginsToInstall.push(ambientPlugin);
     }
 
     const { skillsMap, agentsMap } = buildAssetMaps(pluginsToInstall);


### PR DESCRIPTION
## Summary

- Filter `devflow-ambient` from the plugin multiselect and preSelected defaults (follows `devflow-core-skills` precedent)
- Auto-include `devflow-ambient` when the "Enable ambient mode?" prompt is answered yes
- Removes redundancy: the ambient prompt now controls both hook installation AND plugin inclusion

## Context

The init wizard previously showed `devflow-ambient` in the plugin multiselect (pre-selected) AND had a separate "Enable ambient mode?" prompt. Since `/ambient` was removed and ambient is hook-only, the plugin's sole purpose is distributing skills/agents the hook needs — it shouldn't be a user-facing selection.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 250 tests pass
- [ ] Manual: `node dist/cli.js init` in TTY — confirm `ambient` NOT in plugin list, ambient prompt still appears
- [ ] Manual: `node dist/cli.js init --no-ambient` — confirm ambient plugin NOT installed
- [ ] Manual: `node dist/cli.js init --ambient` — confirm ambient plugin IS installed (auto-included)