### PR TITLE
fix: HUD base branch detection matching raw commit hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,37 @@ Session context is saved and restored automatically via Working Memory hooks —
 | `--teams` / `--no-teams` | Enable/disable Agent Teams (experimental, default: off) |
 | `--ambient` / `--no-ambient` | Enable/disable ambient mode (default: on) |
 | `--memory` / `--no-memory` | Enable/disable working memory (default: on) |
+| `--hud-only` | Install only the HUD (no plugins, hooks, or extras) |
+| `--no-hud` | Disable HUD status line |
 | `--verbose` | Show detailed output |
+
+### HUD Options
+
+| Command | Description |
+|---------|-------------|
+| `npx devflow-kit hud --status` | Show current HUD config |
+| `npx devflow-kit hud --enable` | Enable HUD |
+| `npx devflow-kit hud --disable` | Disable HUD (version notifications still appear) |
+| `npx devflow-kit hud --detail` | Show tool/agent descriptions |
+| `npx devflow-kit hud --no-detail` | Hide tool/agent descriptions |
+
+### Skill Shadowing
+
+Override any DevFlow skill with your own version. Shadowed skills survive `devflow init` — they won't be overwritten on reinstall or upgrade.
+
+```bash
+# Create a personal override (copies current version as reference)
+npx devflow-kit skills shadow core-patterns
+
+# Edit your override
+vim ~/.claude/skills/core-patterns/SKILL.md
+
+# List all overrides
+npx devflow-kit skills list-shadowed
+
+# Remove override (next init restores DevFlow's version)
+npx devflow-kit skills unshadow core-patterns
+```
 
 ### Uninstall Options
 

--- a/src/cli/hud/git.ts
+++ b/src/cli/hud/git.ts
@@ -149,13 +149,13 @@ async function detectBaseBranch(
     const match = line.match(checkoutPattern);
     if (match) {
       const candidate = match[1];
-      if (candidate !== branch) {
-        const exists = await gitExec(
-          ['rev-parse', '--verify', candidate],
-          cwd,
-        );
-        if (exists) return candidate;
-      }
+      // Skip raw commit hashes and the current branch
+      if (candidate === branch || /^[0-9a-f]{7,}$/.test(candidate)) continue;
+      const exists = await gitExec(
+        ['rev-parse', '--verify', candidate],
+        cwd,
+      );
+      if (exists) return candidate;
     }
   }
 
@@ -169,8 +169,14 @@ async function detectBaseBranch(
     if (exists) return prBase;
   }
 
-  // Layer 4: main/master fallback
+  // Layer 4: main/master fallback (skip if already on that branch — use remote tracking instead)
   for (const candidate of ['main', 'master']) {
+    if (candidate === branch) {
+      // On main/master itself — compare against remote tracking branch
+      const remote = await gitExec(['rev-parse', '--verify', `origin/${candidate}`], cwd);
+      if (remote) return `origin/${candidate}`;
+      continue;
+    }
     const exists = await gitExec(['rev-parse', '--verify', candidate], cwd);
     if (exists) return candidate;
   }


### PR DESCRIPTION
## Summary

- Fix `detectBaseBranch` layer 2 (HEAD reflog) matching raw commit hashes from old detached-HEAD checkouts, causing bogus ahead/behind counts (e.g. `50↑ 1↓` when on main)
- When on `main`/`master`, compare against `origin/main` instead of `main` vs `main` (always 0/0)
- Add skill shadowing docs and HUD options to README

## Test plan

- [x] `npm test` — 364/364 passing
- [x] On `main` branch, HUD should show 0↑ 0↓ (or omit ahead/behind entirely)
- [ ] Visual verification after `devflow init --hud-only`