### PR TITLE
fix(hud): version badge cache ignores post-install version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **HUD**: version upgrade notice persists after install — cache now stores only npm `latest`, reads installed version live
+
 ---
 
 ## [1.8.2] - 2026-03-22

--- a/src/cli/hud/components/version-badge.ts
+++ b/src/cli/hud/components/version-badge.ts
@@ -9,7 +9,6 @@ const VERSION_CACHE_KEY = 'version-check';
 const VERSION_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
 interface VersionInfo {
-  current: string;
   latest: string;
 }
 
@@ -80,17 +79,17 @@ export default async function versionBadge(
   const current = getCurrentVersion(ctx.devflowDir);
   if (!current) return null;
 
-  // Check cache
+  // Cache only the npm registry result (expensive); current is always live
   let info = readCache<VersionInfo>(VERSION_CACHE_KEY);
   if (!info) {
     const latest = await fetchLatestVersion();
     if (latest) {
-      info = { current, latest };
+      info = { latest };
       writeCache(VERSION_CACHE_KEY, info, VERSION_CACHE_TTL);
     }
   }
 
-  if (info && compareVersions(info.current, info.latest) < 0) {
+  if (info && compareVersions(current, info.latest) < 0) {
     const badge = `\u2726 Devflow v${info.latest} \u00B7 update: npx devflow-kit init`;
     return { text: yellow(badge), raw: badge };
   }


### PR DESCRIPTION
## Summary
- Version badge cached both `current` and `latest` versions with 24h TTL
- After upgrading DevFlow, the stale cached `current` caused the upgrade notice to persist
- Fix: cache only stores `latest` (npm registry result); installed version is always read live from `manifest.json`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 362 tests pass
- [ ] Manual: write stale cache with `current: 1.8.1, latest: 1.8.2` while manifest says `1.8.2` → badge should NOT appear