### PR TITLE
feat(skills): phase protocol enforcement for orchestration skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Working memory files live in a dedicated `.memory/` directory:
 - Target: ~120-150 lines per SKILL.md with progressive disclosure to `references/`
 - Skills default to read-only (`allowed-tools: Read, Grep, Glob`); exceptions: git/review skills add `Bash`, interactive skills add `AskUserQuestion`, `quality-gates` adds `Write` for state persistence, and `router` omits `allowed-tools` entirely (unrestricted, as the main-session orchestrator)
 - All skills live in `shared/skills/` — add to plugin `plugin.json` `skills` array, then `npm run build`
+- Orchestration skills (`*:orch`) follow the Phase Protocol (defined in `router/SKILL.md`) — each phase needs `**Produces:**`/`**Requires:**` annotations and a `## Phase Completion Checklist`
 
 ### Agents
 

--- a/plugins/devflow-audit-claude/commands/audit-claude.md
+++ b/plugins/devflow-audit-claude/commands/audit-claude.md
@@ -19,6 +19,8 @@ Audit CLAUDE.md files against Anthropic's best practices. Finds oversized files,
 
 ### Phase 1: Discovery
 
+**Produces:** CLAUDE_FILES
+
 Find all CLAUDE.md files to audit:
 
 ```bash
@@ -36,6 +38,9 @@ If a specific path argument was provided, use only that file.
 
 ### Phase 2: Analysis
 
+**Produces:** AUDIT_RESULTS
+**Requires:** CLAUDE_FILES
+
 For each discovered file, spawn a `claude-md-auditor` agent:
 
 ```
@@ -52,6 +57,8 @@ Task(
 Run agents in parallel when multiple files are found.
 
 ### Phase 3: Report
+
+**Requires:** AUDIT_RESULTS
 
 Combine all agent outputs into a single report:
 

--- a/plugins/devflow-code-review/commands/code-review-teams.md
+++ b/plugins/devflow-code-review/commands/code-review-teams.md
@@ -21,6 +21,8 @@ Run a comprehensive code review of the current branch by spawning a review team 
 
 #### Step 0a: Discover Worktrees
 
+**Produces:** WORKTREES
+
 1. **Discover reviewable worktrees** using the `devflow:worktree-support` skill discovery algorithm:
    - Run `git worktree list --porcelain` → parse, filter (skip protected/detached/mid-rebase), dedup by branch, sort by recent commit
    - See `~/.claude/skills/devflow:worktree-support/SKILL.md` for the full 7-step algorithm and canonical protected branch list
@@ -30,6 +32,9 @@ Run a comprehensive code review of the current branch by spawning a review team 
 4. **If multiple reviewable worktrees:** report "Found N worktrees with reviewable branches: {list with paths and branches}" and proceed with multi-worktree flow
 
 #### Step 0b: Per-Worktree Pre-Flight (Git Agent)
+
+**Produces:** BRANCH_INFO, PR_INFO
+**Requires:** WORKTREES
 
 For each reviewable worktree, spawn Git agent:
 
@@ -49,6 +54,9 @@ In multi-worktree mode, spawn all pre-flight agents **in a single message** (par
 
 #### Step 0c: Incremental Detection & Timestamp Setup
 
+**Produces:** DIFF_RANGE, REVIEW_DIR, TIMESTAMP
+**Requires:** BRANCH_INFO
+
 For each worktree:
 
 1. Generate timestamp: `YYYY-MM-DD_HHMM`. If directory already exists (same-minute collision), append seconds (`YYYY-MM-DD_HHMMSS`).
@@ -63,6 +71,9 @@ For each worktree:
      - Set `DIFF_RANGE` to `{base_branch}...HEAD`
 
 ### Phase 1: Analyze Changed Files
+
+**Produces:** REVIEWER_LIST
+**Requires:** DIFF_RANGE
 
 Per worktree, detect file types in diff using `DIFF_RANGE` to determine conditional reviews:
 
@@ -84,6 +95,8 @@ Per worktree, detect file types in diff using `DIFF_RANGE` to determine conditio
 
 ### Phase 1b: Load Knowledge Index
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 Load the knowledge index for the current worktree before spawning the review team:
 
 ```bash
@@ -93,6 +106,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries. Pass `KNOWLEDGE_CONTEXT` to each reviewer teammate prompt. Reviewers use `devflow:apply-knowledge` to Read full entry bodies on demand.
 
 ### Phase 2: Spawn Review Team
+
+**Produces:** REVIEWER_OUTPUTS
+**Requires:** DIFF_RANGE, REVIEW_DIR, TIMESTAMP, KNOWLEDGE_CONTEXT, REVIEWER_LIST
 
 **Per worktree**, create an agent team for adversarial review. Always include 4 core perspectives; conditionally add more based on Phase 1 analysis.
 
@@ -166,6 +182,8 @@ Spawn review teammates. For each teammate, compose a self-contained prompt using
 
 ### Phase 2b: Debate Round
 
+**Requires:** REVIEWER_OUTPUTS
+
 After all reviewers complete initial analysis, lead initiates adversarial debate:
 
 Lead initiates debate via broadcast:
@@ -195,6 +213,9 @@ Reviewers message each other directly using SendMessage:
 - Update or withdraw findings based on peer evidence
 
 ### Phase 3: Synthesis and PR Comments
+
+**Produces:** REVIEW_SUMMARY
+**Requires:** REVIEWER_OUTPUTS, REVIEW_DIR, PR_INFO
 
 **WAIT** for debate to complete, then lead produces outputs.
 
@@ -240,6 +261,8 @@ Check for existing inline comments at same file:line before creating new ones."
 
 ### Phase 4: Write Review Head Marker
 
+**Requires:** BRANCH_INFO, REVIEW_DIR
+
 Per worktree, after successful completion:
 1. Write current HEAD SHA to `{worktree_path}/.docs/reviews/{branch-slug}/.last-review-head`
 
@@ -247,6 +270,8 @@ Per worktree, after successful completion:
      capability; pitfall recording is handled by the background-learning extractor. -->
 
 ### Phase 5: Cleanup and Report
+
+**Requires:** REVIEW_SUMMARY
 
 Shut down all review teammates explicitly:
 

--- a/plugins/devflow-code-review/commands/code-review.md
+++ b/plugins/devflow-code-review/commands/code-review.md
@@ -28,6 +28,8 @@ Run a comprehensive code review of the current branch by spawning parallel revie
 
 #### Step 0a: Discover Worktrees
 
+**Produces:** WORKTREES
+
 1. **Discover reviewable worktrees** using the `devflow:worktree-support` skill discovery algorithm:
    - Run `git worktree list --porcelain` → parse, filter (skip protected/detached/mid-rebase), dedup by branch, sort by recent commit
    - See `~/.claude/skills/devflow:worktree-support/SKILL.md` for the full 7-step algorithm and canonical protected branch list
@@ -37,6 +39,9 @@ Run a comprehensive code review of the current branch by spawning parallel revie
 4. **If multiple reviewable worktrees:** report "Found N worktrees with reviewable branches: {list with paths and branches}" and proceed with multi-worktree flow
 
 #### Step 0b: Per-Worktree Pre-Flight (Git Agent)
+
+**Produces:** BRANCH_INFO, PR_INFO
+**Requires:** WORKTREES
 
 For each reviewable worktree, spawn Git agent:
 
@@ -56,6 +61,9 @@ In multi-worktree mode, spawn all pre-flight agents **in a single message** (par
 
 #### Step 0c: Incremental Detection & Timestamp Setup
 
+**Produces:** DIFF_RANGE, REVIEW_DIR, TIMESTAMP
+**Requires:** BRANCH_INFO
+
 For each worktree:
 
 1. Generate timestamp: `YYYY-MM-DD_HHMM`. If directory already exists (same-minute collision), append seconds (`YYYY-MM-DD_HHMMSS`).
@@ -70,6 +78,9 @@ For each worktree:
      - Set `DIFF_RANGE` to `{base_branch}...HEAD`
 
 ### Phase 1: Analyze Changed Files
+
+**Produces:** REVIEWER_LIST
+**Requires:** DIFF_RANGE
 
 Per worktree, detect file types in diff using `DIFF_RANGE` to determine conditional reviews:
 
@@ -91,6 +102,8 @@ Per worktree, detect file types in diff using `DIFF_RANGE` to determine conditio
 
 ### Phase 1b: Load Knowledge Index
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 While file analysis runs (or just before spawning reviewers), load the knowledge index for the current worktree:
 
 ```bash
@@ -100,6 +113,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries. Pass `KNOWLEDGE_CONTEXT` to all Reviewer agents. Reviewers use `devflow:apply-knowledge` to Read full entry bodies on demand.
 
 ### Phase 2: Run Reviews (Parallel)
+
+**Produces:** REVIEWER_OUTPUTS
+**Requires:** DIFF_RANGE, REVIEW_DIR, TIMESTAMP, KNOWLEDGE_CONTEXT, REVIEWER_LIST
 
 Spawn Reviewer agents **in a single message**. Always run 7 core reviews; conditionally add more based on changed file types:
 
@@ -141,6 +157,9 @@ In multi-worktree mode, process worktrees **sequentially** (one worktree at a ti
 
 ### Phase 3: Synthesis (Parallel)
 
+**Produces:** REVIEW_SUMMARY
+**Requires:** REVIEWER_OUTPUTS, REVIEW_DIR, PR_INFO
+
 **WAIT** for Phase 2, then spawn agents per worktree **in a single message**:
 
 **Git Agent (PR Comments)** per worktree:
@@ -168,6 +187,8 @@ Output: {worktree_path}/.docs/reviews/{branch-slug}/{timestamp}/review-summary.m
 ```
 
 ### Phase 4: Write Review Head Marker & Report
+
+**Requires:** BRANCH_INFO, REVIEW_DIR
 
 Per worktree, after successful completion:
 1. Write current HEAD SHA to `{worktree_path}/.docs/reviews/{branch-slug}/.last-review-head`

--- a/plugins/devflow-debug/commands/debug-teams.md
+++ b/plugins/devflow-debug/commands/debug-teams.md
@@ -25,6 +25,8 @@ Investigate bugs by spawning a team of agents, each pursuing a different hypothe
 
 ### Phase 1: Load Knowledge Index (Orchestrator-Local)
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 Before hypothesizing, load the knowledge index:
 
 ```bash
@@ -34,6 +36,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 The orchestrator uses `KNOWLEDGE_CONTEXT` locally when generating hypotheses (Phase 2) — prior pitfalls and decisions can suggest specific root causes to investigate. Follow `devflow:apply-knowledge` to Read full entry bodies on demand. **Do NOT pass `KNOWLEDGE_CONTEXT` to investigator teammates** — knowledge context stays in the orchestrator; teammates examine code directly.
 
 ### Phase 2: Context Gathering
+
+**Produces:** HYPOTHESES, BUG_CONTEXT
+**Requires:** KNOWLEDGE_CONTEXT
 
 If `$ARGUMENTS` starts with `#`, fetch the GitHub issue:
 
@@ -50,6 +55,8 @@ Analyze the bug description (from arguments or issue) and identify 3-5 plausible
 - **Distinct**: Does not overlap significantly with other hypotheses
 
 ### Phase 3: Spawn Investigation Team
+
+**Requires:** HYPOTHESES, BUG_CONTEXT
 
 Create an agent team with one investigator per hypothesis:
 
@@ -111,6 +118,9 @@ Spawn investigator teammates with self-contained prompts:
 
 ### Phase 4: Investigation
 
+**Produces:** INVESTIGATION_RESULTS
+**Requires:** HYPOTHESES
+
 Teammates investigate in parallel:
 - Read relevant source files
 - Trace execution paths
@@ -119,6 +129,8 @@ Teammates investigate in parallel:
 - Build evidence for or against their hypothesis
 
 ### Phase 5: Adversarial Debate
+
+**Requires:** INVESTIGATION_RESULTS
 
 Lead initiates debate via broadcast:
 
@@ -147,6 +159,9 @@ Teammates challenge each other directly using SendMessage:
 
 ### Phase 6: Convergence
 
+**Produces:** CONVERGENCE_RESULTS
+**Requires:** INVESTIGATION_RESULTS
+
 After debate (max 2 rounds), lead collects results:
 
 ```
@@ -158,6 +173,8 @@ Lead broadcast:
 ```
 
 ### Phase 7: Cleanup
+
+**Requires:** CONVERGENCE_RESULTS
 
 Shut down all investigator teammates explicitly:
 
@@ -171,6 +188,8 @@ Verify TeamDelete succeeded. If failed, retry once after 5s. If retry fails, HAL
 ```
 
 ### Phase 8: Report
+
+**Requires:** CONVERGENCE_RESULTS
 
 Lead produces final report:
 

--- a/plugins/devflow-debug/commands/debug.md
+++ b/plugins/devflow-debug/commands/debug.md
@@ -33,6 +33,8 @@ Investigate bugs by spawning parallel agents, each pursuing a different hypothes
 
 ### Phase 1: Load Knowledge Index (Orchestrator-Local)
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 Before hypothesizing, load the knowledge index:
 
 ```bash
@@ -42,6 +44,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 The orchestrator uses `KNOWLEDGE_CONTEXT` locally when generating hypotheses (Phase 2) — prior pitfalls and decisions can suggest specific root causes to investigate. Follow `devflow:apply-knowledge` to Read full entry bodies on demand. **Do NOT pass `KNOWLEDGE_CONTEXT` to Explore investigators** — knowledge context stays in the orchestrator; investigators examine code directly.
 
 ### Phase 2: Context Gathering
+
+**Produces:** HYPOTHESES, BUG_CONTEXT
+**Requires:** KNOWLEDGE_CONTEXT
 
 If `$ARGUMENTS` starts with `#`, fetch the GitHub issue:
 
@@ -58,6 +63,9 @@ Analyze the bug description (from arguments or issue) and identify 3-5 plausible
 - **Distinct**: Does not overlap significantly with other hypotheses
 
 ### Phase 3: Investigate (Parallel)
+
+**Produces:** INVESTIGATION_RESULTS
+**Requires:** HYPOTHESES
 
 Spawn one Explore agent per hypothesis in a **single message** (parallel execution):
 
@@ -102,6 +110,9 @@ Focus area: {specific code area, mechanism, or condition}
 
 ### Phase 4: Synthesize
 
+**Produces:** ROOT_CAUSE_SYNTHESIS
+**Requires:** INVESTIGATION_RESULTS
+
 Once all investigators return, spawn a Synthesizer agent to aggregate findings:
 
 ```
@@ -119,6 +130,8 @@ Instructions:
 ```
 
 ### Phase 5: Report
+
+**Requires:** ROOT_CAUSE_SYNTHESIS
 
 Produce the final report:
 

--- a/plugins/devflow-implement/commands/implement-teams.md
+++ b/plugins/devflow-implement/commands/implement-teams.md
@@ -29,6 +29,8 @@ Orchestrate a single task through implementation by spawning specialized agent t
 
 ### Phase 1: Setup
 
+**Produces:** TASK_ID, BASE_BRANCH, EXECUTION_PLAN
+
 Record the current branch name as `BASE_BRANCH` - this will be the PR target.
 
 Spawn Git agent to set up task environment. The Git agent derives the branch name automatically from the issue or task description:
@@ -59,6 +61,9 @@ Return the branch setup summary."
 6. Captured values override defaults from Git agent where present
 
 ### Phase 2: Implement
+
+**Produces:** CODER_OUTPUT, FILES_CHANGED
+**Requires:** TASK_ID, BASE_BRANCH, EXECUTION_PLAN
 
 Based on Setup context (plan document, issue body, or conversation context), use the three-strategy framework:
 
@@ -157,6 +162,9 @@ DOMAIN: {subtask 2 domain}"
 
 ### Phase 3: Validate
 
+**Produces:** VALIDATION_RESULT
+**Requires:** FILES_CHANGED
+
 After Coder completes, spawn Validator to verify correctness:
 
 ```
@@ -187,6 +195,9 @@ Run build, typecheck, lint, test. Report pass/fail with failure details."
 
 ### Phase 4: Simplify
 
+**Produces:** SIMPLIFIER_OUTPUT
+**Requires:** FILES_CHANGED
+
 After validation passes, spawn Simplifier to polish the code:
 
 ```
@@ -198,6 +209,9 @@ Focus on code modified by Coder, apply project standards, enhance clarity"
 ```
 
 ### Phase 5: Self-Review
+
+**Produces:** SCRUTINIZER_OUTPUT
+**Requires:** FILES_CHANGED
 
 After Simplifier completes, spawn Scrutinizer as final quality gate:
 
@@ -211,6 +225,9 @@ Evaluate 9 pillars, fix P0/P1 issues, report status"
 If Scrutinizer returns BLOCKED, report to user and halt.
 
 ### Phase 6: Re-Validate (if Scrutinizer made changes)
+
+**Produces:** REVALIDATION_RESULT
+**Requires:** SCRUTINIZER_OUTPUT
 
 If Scrutinizer made code changes (status: FIXED), spawn Validator to verify:
 
@@ -226,6 +243,9 @@ Verify Scrutinizer's fixes didn't break anything."
 **If PASS:** Continue to Phase 7
 
 ### Phase 7: Evaluator↔Coder Dialogue
+
+**Produces:** ALIGNMENT_RESULT
+**Requires:** FILES_CHANGED, EXECUTION_PLAN
 
 After Scrutinizer passes (and re-validation if needed), check alignment using direct dialogue:
 
@@ -318,6 +338,9 @@ Step 3: GATE — Verify TeamDelete succeeded
 
 ### Phase 8: QA Testing
 
+**Produces:** QA_RESULT
+**Requires:** FILES_CHANGED, EXECUTION_PLAN
+
 After Evaluator passes, spawn Tester for scenario-based acceptance testing (standalone agent, not a teammate — testing is sequential, not debate):
 
 ```
@@ -357,11 +380,16 @@ Design and execute scenario-based acceptance tests. Report PASS or FAIL with evi
 
 ### Phase 9: Create PR
 
+**Produces:** PR_URL
+**Requires:** BASE_BRANCH, TASK_ID
+
 **For SEQUENTIAL_CODERS or PARALLEL_CODERS**: The last sequential Coder (with CREATE_PR: true) handles PR creation. For parallel coders, create unified PR using `devflow:git` skill patterns. Push branch and run `gh pr create` with comprehensive description, targeting `BASE_BRANCH`.
 
 **For SINGLE_CODER**: PR is created by the Coder agent (CREATE_PR: true).
 
 ### Phase 10: Report
+
+**Requires:** VALIDATION_RESULT, ALIGNMENT_RESULT, QA_RESULT, PR_URL
 
 Display completion summary with phase status, PR info, and next steps.
 

--- a/plugins/devflow-implement/commands/implement.md
+++ b/plugins/devflow-implement/commands/implement.md
@@ -36,6 +36,8 @@ Orchestrate a single task through implementation by spawning specialized agents.
 
 ### Phase 1: Setup
 
+**Produces:** TASK_ID, BASE_BRANCH, EXECUTION_PLAN
+
 Record the current branch name as `BASE_BRANCH` - this will be the PR target.
 
 Spawn Git agent to set up task environment. The Git agent derives the branch name automatically from the issue or task description:
@@ -66,6 +68,9 @@ Return the branch setup summary."
 6. Captured values override defaults from Git agent where present
 
 ### Phase 2: Implement
+
+**Produces:** CODER_OUTPUT, FILES_CHANGED
+**Requires:** TASK_ID, BASE_BRANCH, EXECUTION_PLAN
 
 Based on Setup context (plan document, issue body, or conversation context), use the three-strategy framework:
 
@@ -164,6 +169,9 @@ DOMAIN: {subtask 2 domain}"
 
 ### Phase 3: Validate
 
+**Produces:** VALIDATION_RESULT
+**Requires:** FILES_CHANGED
+
 After Coder completes, spawn Validator to verify correctness:
 
 ```
@@ -194,6 +202,9 @@ Run build, typecheck, lint, test. Report pass/fail with failure details."
 
 ### Phase 4: Simplify
 
+**Produces:** SIMPLIFIER_OUTPUT
+**Requires:** FILES_CHANGED
+
 After validation passes, spawn Simplifier to polish the code:
 
 ```
@@ -205,6 +216,9 @@ Focus on code modified by Coder, apply project standards, enhance clarity"
 ```
 
 ### Phase 5: Self-Review
+
+**Produces:** SCRUTINIZER_OUTPUT
+**Requires:** FILES_CHANGED
 
 After Simplifier completes, spawn Scrutinizer as final quality gate:
 
@@ -218,6 +232,9 @@ Evaluate 9 pillars, fix P0/P1 issues, report status"
 If Scrutinizer returns BLOCKED, report to user and halt.
 
 ### Phase 6: Re-Validate (if Scrutinizer made changes)
+
+**Produces:** REVALIDATION_RESULT
+**Requires:** SCRUTINIZER_OUTPUT
 
 If Scrutinizer made code changes (status: FIXED), spawn Validator to verify:
 
@@ -233,6 +250,9 @@ Verify Scrutinizer's fixes didn't break anything."
 **If PASS:** Continue to Phase 7
 
 ### Phase 7: Alignment Check
+
+**Produces:** ALIGNMENT_RESULT
+**Requires:** FILES_CHANGED, EXECUTION_PLAN
 
 After Scrutinizer passes (and re-validation if needed), spawn Evaluator to validate alignment:
 
@@ -273,6 +293,9 @@ Validate alignment with request and plan. Report ALIGNED or MISALIGNED with deta
 
 ### Phase 8: QA Testing
 
+**Produces:** QA_RESULT
+**Requires:** FILES_CHANGED, EXECUTION_PLAN
+
 After Evaluator passes, spawn Tester for scenario-based acceptance testing:
 
 ```
@@ -312,11 +335,16 @@ Design and execute scenario-based acceptance tests. Report PASS or FAIL with evi
 
 ### Phase 9: Create PR
 
+**Produces:** PR_URL
+**Requires:** BASE_BRANCH, TASK_ID
+
 **For SEQUENTIAL_CODERS or PARALLEL_CODERS**: The last sequential Coder (with CREATE_PR: true) handles PR creation. For parallel coders, create unified PR using `devflow:git` skill patterns. Push branch and run `gh pr create` with comprehensive description, targeting `BASE_BRANCH`.
 
 **For SINGLE_CODER**: PR is created by the Coder agent (CREATE_PR: true).
 
 ### Phase 10: Report
+
+**Requires:** VALIDATION_RESULT, ALIGNMENT_RESULT, QA_RESULT, PR_URL
 
 Display completion summary with phase status, PR info, and next steps.
 

--- a/plugins/devflow-plan/commands/plan-teams.md
+++ b/plugins/devflow-plan/commands/plan-teams.md
@@ -47,6 +47,8 @@ No gate may be skipped. If user says "proceed" or "whatever you think", state re
 
 #### Phase 1: Gate 0 — Confirm Understanding
 
+**Produces:** CONFIRMED_SCOPE
+
 Present interpretation using AskUserQuestion:
 - Core problem this solves
 - Target users
@@ -58,6 +60,9 @@ For multi-issue: present unified scope across all issues.
 **MANDATORY**: Do not spawn any agents or teams until Gate 0 is confirmed.
 
 #### Phase 2: Orient + Load Knowledge
+
+**Produces:** SKIMMER_CONTEXT, KNOWLEDGE_CONTEXT
+**Requires:** CONFIRMED_SCOPE
 
 Spawn Skimmer agent for codebase context:
 
@@ -81,6 +86,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries. Pass Skimmer context and `KNOWLEDGE_CONTEXT` to all subsequent agents and teammates — prior decisions constrain design, known pitfalls inform gap analysis. Agents use `devflow:apply-knowledge` to Read full entry bodies on demand.
 
 #### Phase 3: Exploration Team
+
+**Produces:** EXPLORE_OUTPUTS
+**Requires:** SKIMMER_CONTEXT, KNOWLEDGE_CONTEXT
 
 Create an agent team for collaborative requirements exploration:
 
@@ -165,6 +173,9 @@ Step 3: GATE — Verify TeamDelete succeeded
 
 #### Phase 4: Synthesize Exploration
 
+**Produces:** EXPLORATION_SYNTHESIS
+**Requires:** EXPLORE_OUTPUTS
+
 ```
 Agent(subagent_type="Synthesizer"):
 "Synthesize EXPLORATION outputs for: {feature/issues}
@@ -178,6 +189,9 @@ Combine into: user needs, similar features, constraints, failure modes"
 ### Block 2: Gap Analysis
 
 #### Phase 5: Gap Analysis (Parallel Subagents)
+
+**Produces:** GAP_OUTPUTS
+**Requires:** EXPLORATION_SYNTHESIS, SKIMMER_CONTEXT, KNOWLEDGE_CONTEXT
 
 Gap analysis uses parallel subagents, not a team — designers work independently on different focus areas; debate between them has no value.
 
@@ -207,6 +221,9 @@ Each designer receives:
 
 #### Phase 6: Synthesize Gap Analysis
 
+**Produces:** GAP_SYNTHESIS
+**Requires:** GAP_OUTPUTS
+
 ```
 Agent(subagent_type="Synthesizer"):
 "Synthesize GAP ANALYSIS outputs for: {feature/issues}
@@ -220,6 +237,9 @@ Deduplicate, boost confidence for multi-agent flags, categorize by severity."
 ### Block 3: Scope Approval
 
 #### Phase 7: Gate 1 — Validate Scope + Gaps
+
+**Produces:** ACCEPTED_SCOPE, ACCEPTED_GAPS
+**Requires:** GAP_SYNTHESIS, EXPLORATION_SYNTHESIS
 
 Use AskUserQuestion to present:
 
@@ -236,6 +256,9 @@ User can: accept, modify scope, or override specific gaps.
 
 #### Phase 8: Explore Implementation (Parallel Subagents)
 
+**Produces:** IMPL_EXPLORE_OUTPUTS
+**Requires:** SKIMMER_CONTEXT, ACCEPTED_SCOPE
+
 Spawn 4 Explore agents **in a single message**, each with Skimmer context + accepted scope:
 
 | Focus | Thoroughness | Find |
@@ -247,6 +270,9 @@ Spawn 4 Explore agents **in a single message**, each with Skimmer context + acce
 
 #### Phase 9: Synthesize Implementation Exploration
 
+**Produces:** IMPL_EXPLORATION_SYNTHESIS
+**Requires:** IMPL_EXPLORE_OUTPUTS
+
 ```
 Agent(subagent_type="Synthesizer"):
 "Synthesize IMPLEMENTATION EXPLORATION outputs for: {feature/issues}
@@ -256,6 +282,9 @@ Combine into: patterns to follow, integration points, reusable code, edge cases"
 ```
 
 #### Phase 10: Planning Team
+
+**Produces:** PLAN_OUTPUTS
+**Requires:** IMPL_EXPLORATION_SYNTHESIS, GAP_SYNTHESIS, KNOWLEDGE_CONTEXT
 
 Create an agent team for collaborative implementation planning:
 
@@ -326,6 +355,9 @@ Step 3: GATE — Verify TeamDelete succeeded
 
 #### Phase 11: Synthesize Planning
 
+**Produces:** PLANNING_SYNTHESIS
+**Requires:** PLAN_OUTPUTS
+
 ```
 Agent(subagent_type="Synthesizer"):
 "Synthesize PLANNING outputs for: {feature/issues}
@@ -340,6 +372,9 @@ Combine into: execution plan with strategy decision, gap mitigations integrated"
 
 #### Phase 12: Design Review (Single Subagent)
 
+**Produces:** REVIEW_FINDINGS
+**Requires:** PLANNING_SYNTHESIS
+
 Design review uses a single independent agent — not a team.
 
 ```
@@ -353,6 +388,9 @@ Review the full plan for all 6 anti-patterns. Report all findings with evidence.
 ```
 
 #### Phase 13: Gate 2 — Confirm Plan + Design Review
+
+**Produces:** APPROVED_PLAN
+**Requires:** PLANNING_SYNTHESIS, REVIEW_FINDINGS, GAP_SYNTHESIS
 
 Use AskUserQuestion to present:
 1. Implementation plan summary (execution strategy, key steps, test strategy)
@@ -369,6 +407,8 @@ User can: accept, revise (re-run phases 10-12), or cancel.
 ### Block 6: Output
 
 #### Phase 14: Output
+
+**Requires:** APPROVED_PLAN
 
 **Store design artifact:**
 

--- a/plugins/devflow-plan/commands/plan.md
+++ b/plugins/devflow-plan/commands/plan.md
@@ -47,6 +47,8 @@ No gate may be skipped. If user says "proceed" or "whatever you think", state re
 
 #### Phase 1: Gate 0 — Requirements Discovery
 
+**Produces:** CONFIRMED_SCOPE
+
 Explore the user's intent through focused Socratic questioning before spawning agents.
 
 **Skip discovery when** (semantic assessment, not word count):
@@ -67,6 +69,9 @@ If the user says "skip" or "just proceed" — skip remaining questions, present 
 **MANDATORY**: Do not spawn any agents until Gate 0 is confirmed.
 
 #### Phase 2: Orient + Load Knowledge
+
+**Produces:** SKIMMER_CONTEXT, KNOWLEDGE_CONTEXT
+**Requires:** CONFIRMED_SCOPE
 
 Spawn Skimmer agent for codebase context:
 
@@ -91,6 +96,9 @@ This produces a compact index of active ADR/PF entries. Pass Skimmer context and
 
 #### Phase 3: Explore Requirements (Parallel)
 
+**Produces:** EXPLORE_OUTPUTS
+**Requires:** SKIMMER_CONTEXT, KNOWLEDGE_CONTEXT
+
 Spawn 4 Explore agents **in a single message**, each with Skimmer context and `KNOWLEDGE_CONTEXT` (from Phase 2). Include instruction: "follow `devflow:apply-knowledge` for KNOWLEDGE_CONTEXT".
 
 | Focus | Thoroughness | Find |
@@ -101,6 +109,9 @@ Spawn 4 Explore agents **in a single message**, each with Skimmer context and `K
 | Failure modes | quick | Error states, edge cases, known pitfalls |
 
 #### Phase 4: Synthesize Exploration
+
+**Produces:** EXPLORATION_SYNTHESIS
+**Requires:** EXPLORE_OUTPUTS
 
 **WAIT** for Phase 3 to complete.
 
@@ -117,6 +128,9 @@ Combine into: user needs, similar features, constraints, failure modes"
 ### Block 2: Gap Analysis
 
 #### Phase 5: Gap Analysis (Parallel)
+
+**Produces:** GAP_OUTPUTS
+**Requires:** EXPLORATION_SYNTHESIS, SKIMMER_CONTEXT, KNOWLEDGE_CONTEXT
 
 **Single-issue**: Spawn 4 Designer agents **in a single message**:
 
@@ -157,6 +171,9 @@ Cite evidence from provided artifacts."
 
 #### Phase 6: Synthesize Gap Analysis
 
+**Produces:** GAP_SYNTHESIS
+**Requires:** GAP_OUTPUTS
+
 **WAIT** for Phase 5 to complete.
 
 ```
@@ -172,6 +189,9 @@ Deduplicate, boost confidence for multi-agent flags, categorize by severity."
 ### Block 3: Scope Approval
 
 #### Phase 7: Gate 1 — Validate Scope + Gaps
+
+**Produces:** ACCEPTED_SCOPE, ACCEPTED_GAPS
+**Requires:** GAP_SYNTHESIS, EXPLORATION_SYNTHESIS
 
 Use AskUserQuestion to present and validate:
 
@@ -199,6 +219,9 @@ User can:
 
 #### Phase 8: Explore Implementation (Parallel)
 
+**Produces:** IMPL_EXPLORE_OUTPUTS
+**Requires:** SKIMMER_CONTEXT, ACCEPTED_SCOPE
+
 Spawn 4 Explore agents **in a single message**, each with Skimmer context + accepted scope:
 
 | Focus | Thoroughness | Find |
@@ -209,6 +232,9 @@ Spawn 4 Explore agents **in a single message**, each with Skimmer context + acce
 | Edge cases | quick | Error scenarios, race conditions, permission failures |
 
 #### Phase 9: Synthesize Implementation Exploration
+
+**Produces:** IMPL_EXPLORATION_SYNTHESIS
+**Requires:** IMPL_EXPLORE_OUTPUTS
 
 **WAIT** for Phase 8 to complete.
 
@@ -222,6 +248,9 @@ Combine into: patterns to follow, integration points, reusable code, edge cases"
 
 #### Phase 10: Plan Implementation (Parallel)
 
+**Produces:** PLAN_OUTPUTS
+**Requires:** IMPL_EXPLORATION_SYNTHESIS, GAP_SYNTHESIS, KNOWLEDGE_CONTEXT
+
 Spawn 3 Plan agents **in a single message**, each with implementation exploration synthesis:
 
 | Focus | Output |
@@ -233,6 +262,9 @@ Spawn 3 Plan agents **in a single message**, each with implementation exploratio
 Implementation steps planner: include explicit gap mitigations (from Phase 6) in the relevant steps.
 
 #### Phase 11: Synthesize Planning
+
+**Produces:** PLANNING_SYNTHESIS
+**Requires:** PLAN_OUTPUTS
 
 **WAIT** for Phase 10 to complete.
 
@@ -250,6 +282,9 @@ Combine into: execution plan with strategy decision, gap mitigations integrated"
 
 #### Phase 12: Design Review
 
+**Produces:** REVIEW_FINDINGS
+**Requires:** PLANNING_SYNTHESIS
+
 Spawn 1 Designer agent with mode `design-review`:
 
 ```
@@ -263,6 +298,9 @@ Review the full plan for all 6 anti-patterns. Report all findings with evidence.
 ```
 
 #### Phase 13: Gate 2 — Confirm Plan + Design Review
+
+**Produces:** APPROVED_PLAN
+**Requires:** PLANNING_SYNTHESIS, REVIEW_FINDINGS, GAP_SYNTHESIS
 
 Use AskUserQuestion to present:
 
@@ -293,6 +331,8 @@ User can:
 ### Block 6: Output
 
 #### Phase 14: Output
+
+**Requires:** APPROVED_PLAN
 
 **Store design artifact:**
 

--- a/plugins/devflow-resolve/commands/resolve-teams.md
+++ b/plugins/devflow-resolve/commands/resolve-teams.md
@@ -21,6 +21,8 @@ Process issues from code review reports: validate them (false positive check), a
 
 #### Step 0a: Discover Worktrees
 
+**Produces:** WORKTREES
+
 1. **Discover resolvable worktrees** using the `devflow:worktree-support` skill discovery algorithm:
    - Run `git worktree list --porcelain` → parse, filter (skip protected/detached/mid-rebase), dedup by branch, sort by recent commit
    - See `~/.claude/skills/devflow:worktree-support/SKILL.md` for the full 7-step algorithm and canonical protected branch list
@@ -31,6 +33,9 @@ Process issues from code review reports: validate them (false positive check), a
 4. **If multiple resolvable worktrees:** report "Found N worktrees with unresolved reviews: {list}" and proceed with multi-worktree flow
 
 #### Step 0b: Per-Worktree Pre-Flight (Git Agent)
+
+**Produces:** BRANCH_INFO
+**Requires:** WORKTREES
 
 For each resolvable worktree, spawn Git agent:
 
@@ -50,6 +55,9 @@ In multi-worktree mode, spawn all pre-flight agents **in a single message** (par
 
 #### Step 0c: Target Review Directory
 
+**Produces:** TARGET_DIR
+**Requires:** BRANCH_INFO
+
 For each worktree:
 
 1. List directories in `{worktree}/.docs/reviews/{branch-slug}/`
@@ -62,6 +70,8 @@ Set `TARGET_DIR` to the selected review directory path.
 
 #### Step 0d: Load Project Knowledge
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 For each worktree, run:
 
 ```bash
@@ -71,6 +81,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries from `decisions.md` and `pitfalls.md`, with Deprecated/Superseded entries already stripped. Falls back to `(none)` when both files are absent or all entries are filtered. Pass `KNOWLEDGE_CONTEXT` to every Resolver agent in Phase 4. Resolver agents use `devflow:apply-knowledge` to Read full entry bodies on demand — no fan-out of the full corpus.
 
 ### Phase 1: Parse Issues
+
+**Produces:** ISSUES
+**Requires:** TARGET_DIR
 
 Read review reports from `{TARGET_DIR}/*.md` and extract:
 
@@ -94,6 +107,9 @@ Issues are extracted from `{TARGET_DIR}` only — never cross-reference reviews 
 
 ### Phase 2: Analyze Dependencies
 
+**Produces:** DEPENDENCY_GRAPH
+**Requires:** ISSUES
+
 Group issues by relationship:
 
 1. **Same file** - Issues in same file go in same batch
@@ -104,12 +120,18 @@ Build dependency graph to determine execution order.
 
 ### Phase 3: Plan Batches
 
+**Produces:** BATCHES
+**Requires:** DEPENDENCY_GRAPH
+
 Create execution plan:
 - **Independent batches** - Mark for PARALLEL execution
 - **Dependent batches** - Mark for SEQUENTIAL execution
 - **Max 5 issues per batch** - Keep batches manageable
 
 ### Phase 4: Resolve (Agent Teams with cross-validation)
+
+**Produces:** RESOLUTION_RESULTS
+**Requires:** BATCHES, KNOWLEDGE_CONTEXT, BRANCH_INFO
 
 **With Agent Teams:**
 
@@ -187,6 +209,9 @@ For dependent batches that cannot run in parallel, spawn sequentially within the
 
 ### Phase 5: Collect Results
 
+**Produces:** AGGREGATED_RESULTS, KNOWLEDGE_CITATIONS
+**Requires:** RESOLUTION_RESULTS
+
 Aggregate from all Resolvers:
 - **Fixed**: Issues resolved with commits
 - **False positives**: Issues that don't exist or were misunderstood
@@ -200,6 +225,9 @@ Extract all knowledge citations from Resolver Reasoning columns. Collect unique 
 
 ### Phase 6: Simplify
 
+**Produces:** SIMPLIFICATION_RESULT
+**Requires:** RESOLUTION_RESULTS
+
 If any fixes were made, spawn Simplifier agent to refine the changed code:
 
 ```
@@ -211,6 +239,9 @@ Simplify and refine the fixes for clarity and consistency"
 ```
 
 ### Phase 7: Manage Tech Debt (Sequential)
+
+**Produces:** DEBT_RESULT
+**Requires:** RESOLUTION_RESULTS, TARGET_DIR
 
 **IMPORTANT**: Run sequentially across all worktrees (not in parallel) to avoid GitHub API conflicts.
 
@@ -226,6 +257,8 @@ Note: Deferred issues from resolution are already in resolution-summary.md"
 ```
 
 ### Phase 8: Report
+
+**Requires:** AGGREGATED_RESULTS, KNOWLEDGE_CITATIONS, TARGET_DIR
 
 **Write the resolution summary** to `{TARGET_DIR}/resolution-summary.md` using Write tool, then display:
 

--- a/plugins/devflow-resolve/commands/resolve.md
+++ b/plugins/devflow-resolve/commands/resolve.md
@@ -28,6 +28,8 @@ Process issues from code review reports: validate them (false positive check), a
 
 #### Step 0a: Discover Worktrees
 
+**Produces:** WORKTREES
+
 1. **Discover resolvable worktrees** using the `devflow:worktree-support` skill discovery algorithm:
    - Run `git worktree list --porcelain` → parse, filter (skip protected/detached/mid-rebase), dedup by branch, sort by recent commit
    - See `~/.claude/skills/devflow:worktree-support/SKILL.md` for the full 7-step algorithm and canonical protected branch list
@@ -38,6 +40,9 @@ Process issues from code review reports: validate them (false positive check), a
 4. **If multiple resolvable worktrees:** report "Found N worktrees with unresolved reviews: {list}" and proceed with multi-worktree flow
 
 #### Step 0b: Per-Worktree Pre-Flight (Git Agent)
+
+**Produces:** BRANCH_INFO
+**Requires:** WORKTREES
 
 For each resolvable worktree, spawn Git agent:
 
@@ -57,6 +62,9 @@ In multi-worktree mode, spawn all pre-flight agents **in a single message** (par
 
 #### Step 0c: Target Review Directory
 
+**Produces:** TARGET_DIR
+**Requires:** BRANCH_INFO
+
 For each worktree:
 
 1. List directories in `{worktree}/.docs/reviews/{branch-slug}/`
@@ -69,6 +77,8 @@ Set `TARGET_DIR` to the selected review directory path.
 
 #### Step 0d: Load Project Knowledge
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 For each worktree, run:
 
 ```bash
@@ -78,6 +88,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries from `decisions.md` and `pitfalls.md`, with Deprecated/Superseded entries already stripped. Falls back to `(none)` when both files are absent or all entries are filtered. Pass `KNOWLEDGE_CONTEXT` to every Resolver agent in Phase 4. Resolver agents use `devflow:apply-knowledge` to Read full entry bodies on demand — no fan-out of the full corpus.
 
 ### Phase 1: Parse Issues
+
+**Produces:** ISSUES
+**Requires:** TARGET_DIR
 
 Read review reports from `{TARGET_DIR}/*.md` and extract:
 
@@ -101,6 +114,9 @@ Issues are extracted from `{TARGET_DIR}` only — never cross-reference reviews 
 
 ### Phase 2: Analyze Dependencies
 
+**Produces:** DEPENDENCY_GRAPH
+**Requires:** ISSUES
+
 Group issues by relationship:
 
 1. **Same file** - Issues in same file go in same batch
@@ -111,12 +127,18 @@ Build dependency graph to determine execution order.
 
 ### Phase 3: Plan Batches
 
+**Produces:** BATCHES
+**Requires:** DEPENDENCY_GRAPH
+
 Create execution plan:
 - **Independent batches** - Mark for PARALLEL execution
 - **Dependent batches** - Mark for SEQUENTIAL execution
 - **Max 5 issues per batch** - Keep batches manageable
 
 ### Phase 4: Resolve (Parallel where possible)
+
+**Produces:** RESOLUTION_RESULTS
+**Requires:** BATCHES, KNOWLEDGE_CONTEXT, BRANCH_INFO
 
 Spawn Resolver agents based on dependency analysis. For independent batches, spawn **in a single message**:
 
@@ -139,6 +161,9 @@ For dependent batches, spawn sequentially and wait for completion before spawnin
 
 ### Phase 5: Collect Results
 
+**Produces:** AGGREGATED_RESULTS, KNOWLEDGE_CITATIONS
+**Requires:** RESOLUTION_RESULTS
+
 Aggregate from all Resolvers:
 - **Fixed**: Issues resolved with commits
 - **False positives**: Issues that don't exist or were misunderstood
@@ -148,6 +173,9 @@ Aggregate from all Resolvers:
 Extract all knowledge citations from Resolver Reasoning columns. Collect unique `applies ADR-NNN` and `avoids PF-NNN` references across all batches. These will populate the `## Knowledge Citations` section in Phase 8.
 
 ### Phase 6: Simplify
+
+**Produces:** SIMPLIFICATION_RESULT
+**Requires:** RESOLUTION_RESULTS
 
 If any fixes were made, spawn Simplifier agent to refine the changed code:
 
@@ -160,6 +188,9 @@ Simplify and refine the fixes for clarity and consistency"
 ```
 
 ### Phase 7: Manage Tech Debt (Sequential)
+
+**Produces:** DEBT_RESULT
+**Requires:** RESOLUTION_RESULTS, TARGET_DIR
 
 **IMPORTANT**: Run sequentially across all worktrees (not in parallel) to avoid GitHub API conflicts.
 
@@ -175,6 +206,8 @@ Note: Deferred issues from resolution are already in resolution-summary.md"
 ```
 
 ### Phase 8: Report
+
+**Requires:** AGGREGATED_RESULTS, KNOWLEDGE_CITATIONS, TARGET_DIR
 
 **Write the resolution summary** to `{TARGET_DIR}/resolution-summary.md` using Write tool, then display:
 

--- a/plugins/devflow-self-review/commands/self-review.md
+++ b/plugins/devflow-self-review/commands/self-review.md
@@ -15,6 +15,8 @@ Run Simplifier and Scrutinizer sequentially on changed files for post-implementa
 
 ### Phase 0: Context Gathering
 
+**Produces:** FILES_CHANGED, TASK_DESCRIPTION, KNOWLEDGE_CONTEXT
+
 Detect changed files and build context:
 
 1. If arguments provided, use those as FILES_CHANGED
@@ -31,6 +33,9 @@ Detect changed files and build context:
 
 ### Phase 1: Simplifier (Code Refinement)
 
+**Produces:** SIMPLIFIER_COMMITS
+**Requires:** FILES_CHANGED, TASK_DESCRIPTION
+
 Spawn Simplifier agent to refine code for clarity and consistency:
 
 Agent(subagent_type="Simplifier", run_in_background=false):
@@ -41,6 +46,9 @@ Simplify and refine the code for clarity and consistency while preserving functi
 **Wait for completion.** Simplifier commits changes directly.
 
 ### Phase 2: Scrutinizer (9-Pillar Quality Gate)
+
+**Produces:** SCRUTINIZER_STATUS, SCRUTINIZER_CHANGES
+**Requires:** FILES_CHANGED, TASK_DESCRIPTION, KNOWLEDGE_CONTEXT
 
 Spawn Scrutinizer agent for quality evaluation and fixing:
 
@@ -55,6 +63,9 @@ Follow devflow:apply-knowledge to scan KNOWLEDGE_CONTEXT and Read full ADR/PF bo
 
 ### Phase 3: Conditional Validation
 
+**Produces:** VALIDATION_RESULT
+**Requires:** SCRUTINIZER_CHANGES
+
 If Scrutinizer made changes (STATUS == FIXED):
 
 Agent(subagent_type="Validator", run_in_background=false):
@@ -66,6 +77,8 @@ Run build, typecheck, lint, test on modified files"
 **If PASS:** Continue to report
 
 ### Phase 4: Report
+
+**Requires:** SCRUTINIZER_STATUS, VALIDATION_RESULT
 
 Display summary:
 

--- a/shared/skills/debug:orch/SKILL.md
+++ b/shared/skills/debug:orch/SKILL.md
@@ -26,6 +26,8 @@ If the orchestrator receives a `WORKTREE_PATH` context (e.g., from multi-worktre
 
 ## Phase 0: Load Knowledge Index (Orchestrator-Local)
 
+**Produces:** KNOWLEDGE_CONTEXT
+
 Before hypothesizing, load the knowledge index:
 
 ```bash
@@ -35,6 +37,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 The orchestrator uses `KNOWLEDGE_CONTEXT` locally when generating hypotheses (Phase 1) — prior pitfalls and decisions can suggest specific root causes to investigate. Follow `devflow:apply-knowledge` to Read full entry bodies on demand. **Do NOT pass `KNOWLEDGE_CONTEXT` to Explore sub-agents** — knowledge context stays in the orchestrator, not in the investigation workers.
 
 ## Phase 1: Hypothesize
+
+**Produces:** HYPOTHESES
+**Requires:** KNOWLEDGE_CONTEXT
 
 Analyze the bug description, error messages, and conversation context. Generate 3-5 hypotheses that are:
 
@@ -46,6 +51,9 @@ If fewer than 3 hypotheses are possible, proceed with 2.
 
 ## Phase 2: Investigate (Parallel)
 
+**Produces:** INVESTIGATION_RESULTS
+**Requires:** HYPOTHESES
+
 Spawn one `Agent(subagent_type="Explore")` per hypothesis **in a single message** (parallel execution):
 
 - Each investigator searches for evidence FOR and AGAINST its hypothesis
@@ -54,6 +62,9 @@ Spawn one `Agent(subagent_type="Explore")` per hypothesis **in a single message*
 
 ## Phase 3: Converge
 
+**Produces:** CONVERGENCE_DECISION
+**Requires:** INVESTIGATION_RESULTS
+
 Evaluate investigation results:
 
 - **One CONFIRMED**: Spawn 1-2 additional `Agent(subagent_type="Explore")` agents to validate from different angles (prevent confirmation bias)
@@ -61,6 +72,9 @@ Evaluate investigation results:
 - **All DISPROVED**: Report honestly — "No root cause identified from initial hypotheses." Generate 2-3 second-round hypotheses if conversation context suggests avenues not yet explored.
 
 ## Phase 4: Report
+
+**Produces:** ROOT_CAUSE_REPORT
+**Requires:** CONVERGENCE_DECISION, INVESTIGATION_RESULTS
 
 Present root cause analysis:
 
@@ -71,6 +85,8 @@ Present root cause analysis:
 
 ## Phase 5: Offer Fix
 
+**Requires:** ROOT_CAUSE_REPORT
+
 Ask user via AskUserQuestion: "Want me to implement this fix?"
 
 - **YES** → Implement the fix directly in main session using GUIDED approach: load devflow:patterns, devflow:research, and devflow:test-driven-development skills, then code the fix. Spawn `Agent(subagent_type="Simplifier")` on changed files after.
@@ -80,3 +96,16 @@ Ask user via AskUserQuestion: "Want me to implement this fix?"
 
 - **All hypotheses disproved, no second-round ideas**: Report "No root cause identified" with summary of what was investigated and ruled out
 - **Explore agents return insufficient evidence**: Report LOW confidence with available evidence, suggest manual investigation areas
+
+## Phase Completion Checklist
+
+Before reporting results, verify every phase was announced:
+
+- [ ] Phase 0: Load Knowledge Index → KNOWLEDGE_CONTEXT captured
+- [ ] Phase 1: Hypothesize → HYPOTHESES captured (3-5 distinct)
+- [ ] Phase 2: Investigate → INVESTIGATION_RESULTS captured per hypothesis
+- [ ] Phase 3: Converge → CONVERGENCE_DECISION captured
+- [ ] Phase 4: Report → ROOT_CAUSE_REPORT presented
+- [ ] Phase 5: Offer Fix → User asked, response handled
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/explore:orch/SKILL.md
+++ b/shared/skills/explore:orch/SKILL.md
@@ -30,6 +30,8 @@ For GUIDED depth, the main session performs exploration directly:
 
 ### Phase 1: Orient
 
+**Produces:** ORIENT_OUTPUT
+
 Spawn `Agent(subagent_type="Skimmer")` to get codebase overview relevant to the exploration question:
 
 - File structure and module boundaries in the target area
@@ -37,6 +39,9 @@ Spawn `Agent(subagent_type="Skimmer")` to get codebase overview relevant to the 
 - Related patterns and conventions
 
 ### Phase 2: Explore
+
+**Produces:** EXPLORE_OUTPUT
+**Requires:** ORIENT_OUTPUT
 
 Based on Skimmer findings, spawn 2-3 `Agent(subagent_type="Explore")` agents **in a single message** (parallel execution):
 
@@ -48,6 +53,9 @@ Adjust explorer focus based on the specific exploration question.
 
 ### Phase 3: Synthesize
 
+**Produces:** MERGED_FINDINGS
+**Requires:** EXPLORE_OUTPUT
+
 Spawn `Agent(subagent_type="Synthesizer")` in `exploration` mode with combined findings:
 
 - Merge overlapping discoveries from parallel explorers
@@ -55,6 +63,8 @@ Spawn `Agent(subagent_type="Synthesizer")` in `exploration` mode with combined f
 - Organize into the Output format below
 
 ### Phase 4: Present
+
+**Requires:** MERGED_FINDINGS
 
 Main session reviews synthesis for:
 
@@ -78,3 +88,14 @@ Structured exploration findings with concrete code references:
 - Integration Points (module boundaries, shared types, external dependencies)
 - Patterns (recurring conventions, design decisions observed)
 - Key Insights (non-obvious findings, surprises, potential concerns)
+
+## Phase Completion Checklist
+
+Before presenting findings, verify every phase was announced:
+
+- [ ] Phase 1: Orient → ORIENT_OUTPUT captured
+- [ ] Phase 2: Explore → EXPLORE_OUTPUT captured
+- [ ] Phase 3: Synthesize → MERGED_FINDINGS captured
+- [ ] Phase 4: Present → Findings delivered with file:line references
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/implement:orch/SKILL.md
+++ b/shared/skills/implement:orch/SKILL.md
@@ -20,7 +20,24 @@ This is a lightweight variant of `/implement` for ambient ORCHESTRATED mode. Exc
 
 ---
 
+## Continuation Detection
+
+Before starting the full pipeline, check for re-validation context:
+
+- **Re-validation after manual fix**: User explicitly asks to re-validate, re-check, or re-run gates after making their own changes
+
+If this condition is true → execute **Re-validation Path**:
+1. **Branch safety check**: If current branch is protected (main, master, etc.), execute Phase 1 first to create/switch to a work branch. If already on a work branch, skip Phase 1.
+2. Skip Phases 2-3 (no Coder needed)
+3. Run Phase 4 (FILES_CHANGED Detection) using the existing branch
+4. Run Phase 5 (Quality Gates) on detected changes
+5. Proceed to Phase 6 (Completion)
+
+If not → proceed with the full pipeline below.
+
 ## Phase 1: Pre-flight — Branch Safety
+
+**Produces:** BASE_BRANCH, FEATURE_BRANCH
 
 Detect branch type before spawning Coder:
 
@@ -41,6 +58,9 @@ Capture `branch name` and `BASE_BRANCH` from Git agent output for use throughout
 
 ## Phase 2: Plan Synthesis
 
+**Produces:** EXECUTION_PLAN
+**Requires:** FEATURE_BRANCH
+
 Synthesize conversation context into a structured EXECUTION_PLAN for Coder:
 
 - **If a plan exists** in conversation context (from plan mode — accepted in-session or injected after "accept and clear") → use the plan as-is.
@@ -53,6 +73,9 @@ Format as structured markdown with: Goal, Steps, Files, Constraints, Decisions.
 If the orchestrator receives a `WORKTREE_PATH` context (e.g., from multi-worktree workflows), pass it through to all spawned agents. Each agent's "Worktree Support" section handles path resolution.
 
 ## Phase 3: Coder Execution
+
+**Produces:** CODER_COMMITS, PRE_CODER_SHA
+**Requires:** EXECUTION_PLAN, FEATURE_BRANCH
 
 Record git SHA before first Coder: `git rev-parse HEAD`
 
@@ -75,6 +98,9 @@ If Coder returns **BLOCKED**, halt the pipeline and report to user.
 
 ## Phase 4: FILES_CHANGED Detection
 
+**Produces:** FILES_CHANGED
+**Requires:** PRE_CODER_SHA
+
 After Coder completes, detect changed files:
 
 ```bash
@@ -84,6 +110,9 @@ git diff --name-only {starting_sha}...HEAD
 Pass FILES_CHANGED to all quality gate agents.
 
 ## Phase 5: Quality Gates
+
+**Produces:** GATE_RESULTS
+**Requires:** FILES_CHANGED, CODER_COMMITS
 
 Run sequentially — each gate must pass before the next:
 
@@ -97,6 +126,8 @@ Run sequentially — each gate must pass before the next:
 If any gate exhausts retries, halt pipeline and report what passed and what failed.
 
 ## Phase 6: Completion
+
+**Requires:** GATE_RESULTS, FILES_CHANGED, CODER_COMMITS
 
 Cleanup: delete `.docs/handoff.md` if it exists (no longer needed after pipeline completes).
 
@@ -112,3 +143,16 @@ Report results:
 - **Validator fails after retries**: Report specific failures, halt pipeline
 - **Evaluator misalignment after retries**: Report misalignment details, let user decide next steps
 - **Tester QA failures after retries**: Report QA failure details, let user decide next steps
+
+## Phase Completion Checklist
+
+Before reporting results, verify every phase was announced:
+
+- [ ] Phase 1: Pre-flight → BASE_BRANCH, FEATURE_BRANCH captured
+- [ ] Phase 2: Plan Synthesis → EXECUTION_PLAN captured
+- [ ] Phase 3: Coder Execution → CODER_COMMITS, PRE_CODER_SHA captured
+- [ ] Phase 4: FILES_CHANGED Detection → FILES_CHANGED captured
+- [ ] Phase 5: Quality Gates → GATE_RESULTS captured (per gate: pass/fail)
+- [ ] Phase 6: Completion → Results reported
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/pipeline:orch/SKILL.md
+++ b/shared/skills/pipeline:orch/SKILL.md
@@ -22,7 +22,11 @@ Meta-orchestrator chaining implement → review → resolve with status reportin
 Classification statement must warn about scope:
 `Devflow: PIPELINE/ORCHESTRATED. This runs implement → review → resolve (15+ agents across stages).`
 
+**Scoped nesting**: When delegating to inner orch skills (implement:orch, review:orch, resolve:orch), those skills announce their phases with a scoped prefix: `Implement > Phase 1: Pre-flight`, `Review > Phase 3: File Analysis`, etc. Pipeline:orch announces its own phases without prefix.
+
 ## Phase 1: Implement
+
+**Produces:** IMPLEMENT_RESULT
 
 Load `devflow:implement:orch` via the Skill tool, then execute its full pipeline (Phases 1-6: pre-flight → plan synthesis → Coder → FILES_CHANGED detection → quality gates → completion). The quality gates are non-negotiable: Validator → Simplifier → Scrutinizer → re-Validate → Evaluator → Tester.
 
@@ -32,6 +36,9 @@ Cleanup: delete `.docs/handoff.md` if it exists (no longer needed before review)
 
 ## Phase 2: Status — Review Decision
 
+**Produces:** STATUS_DECISION
+**Requires:** IMPLEMENT_RESULT
+
 Log implementation results:
 > "Implementation complete ({n} files changed, all quality gates passed). Proceeding to multi-agent review."
 
@@ -39,11 +46,17 @@ Auto-proceed to Phase 3.
 
 ## Phase 3: Review
 
+**Produces:** REVIEW_RESULT
+**Requires:** IMPLEMENT_RESULT
+
 Load `devflow:review:orch` via the Skill tool, then execute its full pipeline (Phases 1-6: pre-flight → incremental detection → file analysis → parallel reviewers (7 core + conditional) → synthesis → finalize). All 7 core reviewers (security, architecture, performance, complexity, consistency, testing, regression) are mandatory.
 
 Report review results (merge recommendation, issue counts).
 
 ## Phase 4: Status — Resolve Decision
+
+**Produces:** RESOLVE_DECISION
+**Requires:** REVIEW_RESULT
 
 If **blocking issues found**:
 > Log: "Found {n} blocking issues. Auto-resolving."
@@ -55,9 +68,14 @@ If **no blocking issues**:
 
 ## Phase 5: Resolve
 
+**Produces:** RESOLVE_RESULT
+**Requires:** RESOLVE_DECISION, REVIEW_RESULT
+
 Load `devflow:resolve:orch` via the Skill tool, then execute its full pipeline (Phases 1-6: target review directory → parse issues → analyze & batch → parallel resolvers → collect & simplify → report).
 
 ## Phase 6: Summary
+
+**Requires:** IMPLEMENT_RESULT, REVIEW_RESULT, RESOLVE_RESULT
 
 End-to-end report:
 - **Implementation**: files changed, commits, quality gate results
@@ -71,3 +89,16 @@ End-to-end report:
 - **Review finds no changes**: Skip review, report implementation only
 - **All issues resolved**: Report full success
 - **Partial resolution**: Report what was fixed and what remains
+
+## Phase Completion Checklist
+
+Before reporting summary, verify every phase was announced:
+
+- [ ] Phase 1: Implement → IMPLEMENT_RESULT captured
+- [ ] Phase 2: Status — Review Decision → STATUS_DECISION logged
+- [ ] Phase 3: Review → REVIEW_RESULT captured
+- [ ] Phase 4: Status — Resolve Decision → RESOLVE_DECISION logged
+- [ ] Phase 5: Resolve → RESOLVE_RESULT captured (or skipped: no blocking issues — announce skip)
+- [ ] Phase 6: Summary → SUMMARY_REPORT presented
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/plan:orch/SKILL.md
+++ b/shared/skills/plan:orch/SKILL.md
@@ -35,7 +35,29 @@ If the orchestrator receives a `WORKTREE_PATH` context (e.g., from multi-worktre
 
 ---
 
+## Continuation Detection
+
+Before starting the full pipeline, check for prior planning context:
+
+- **Existing artifact**: `.docs/design/` contains a file matching the current topic
+- **Accepted plan in session**: A structured plan was already presented and accepted in this conversation
+
+**Override**: If the user explicitly requests a fresh plan ("start from scratch", "ignore the old plan", "new approach"), execute the full pipeline regardless of prior artifacts.
+
+If EITHER condition is true (and no override) → execute **Refinement Path** instead of Phases 0-8:
+
+1. Read the existing plan (disk artifact or conversation context)
+2. Run Phase 2 (Explore) targeting only areas affected by the new request
+3. Update the plan with changes, preserving unchanged sections
+4. Run Phase 6 (Design Review Lite) on updated sections only
+5. Present the delta (what changed and why)
+6. Proceed to Phase 8 (Persist) if updated plan is substantial
+
+If NEITHER condition is met → proceed with the full pipeline below.
+
 ## Phase 0: Load Knowledge Index
+
+**Produces:** KNOWLEDGE_CONTEXT
 
 Before spawning any agents, load the knowledge index for the current worktree:
 
@@ -46,6 +68,8 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries. Pass `KNOWLEDGE_CONTEXT` to Explorer and Designer agents — prior decisions constrain design, known pitfalls inform gap analysis. Agents use `devflow:apply-knowledge` to Read full entry bodies on demand.
 
 ## Phase 0.5: Requirements Discovery
+
+**Produces:** CONSTRAINED_PROBLEM
 
 Before committing to an approach, surface ambiguity through focused Socratic questioning.
 
@@ -82,6 +106,9 @@ If the user says "skip", "just proceed", or signals impatience — skip remainin
 
 ## Phase 1: Orient
 
+**Produces:** ORIENT_OUTPUT
+**Requires:** CONSTRAINED_PROBLEM (or original prompt if Phase 0.5 skipped)
+
 Spawn `Agent(subagent_type="Skimmer")` to get codebase overview relevant to the planning question:
 
 - Existing patterns and conventions in the affected area
@@ -90,6 +117,9 @@ Spawn `Agent(subagent_type="Skimmer")` to get codebase overview relevant to the 
 - Related prior implementations (similar features, analogous patterns)
 
 ## Phase 2: Explore
+
+**Produces:** EXPLORE_OUTPUT
+**Requires:** ORIENT_OUTPUT, KNOWLEDGE_CONTEXT
 
 Based on Skimmer findings, spawn 2-3 `Agent(subagent_type="Explore")` agents **in a single message** (parallel execution):
 
@@ -102,6 +132,9 @@ Each Explore agent receives `KNOWLEDGE_CONTEXT` (from Phase 0) and the instructi
 Adjust explorer focus based on the specific planning question.
 
 ## Phase 3: Gap Analysis Lite
+
+**Produces:** GAP_OUTPUT
+**Requires:** EXPLORE_OUTPUT, ORIENT_OUTPUT, KNOWLEDGE_CONTEXT
 
 Spawn 2 `Agent(subagent_type="Designer")` agents **in a single message** (parallel execution):
 
@@ -131,6 +164,9 @@ Follow devflow:apply-knowledge for KNOWLEDGE_CONTEXT."
 
 ## Phase 4: Synthesize
 
+**Produces:** SYNTHESIS_OUTPUT
+**Requires:** GAP_OUTPUT, EXPLORE_OUTPUT
+
 Spawn `Agent(subagent_type="Synthesizer")` combining gap analysis and explore outputs:
 
 ```
@@ -142,6 +178,9 @@ Combine gap findings with exploration context into blocking vs. should-address c
 
 ## Phase 5: Plan
 
+**Produces:** PLAN_OUTPUT
+**Requires:** ORIENT_OUTPUT, EXPLORE_OUTPUT, SYNTHESIS_OUTPUT, KNOWLEDGE_CONTEXT
+
 Spawn `Agent(subagent_type="Plan")` with all findings:
 
 - Design implementation approach with file-level specificity
@@ -151,6 +190,9 @@ Spawn `Agent(subagent_type="Plan")` with all findings:
 - Flag areas where existing patterns conflict with the proposed approach
 
 ## Phase 6: Design Review Lite
+
+**Produces:** REVIEW_NOTES
+**Requires:** PLAN_OUTPUT
 
 Main session reviews the plan inline using the loaded `devflow:design-review` skill:
 
@@ -165,6 +207,8 @@ Note findings directly in the plan presentation. This is inline review — no ag
 
 ## Phase 7: Present
 
+**Requires:** PLAN_OUTPUT, SYNTHESIS_OUTPUT, REVIEW_NOTES
+
 Present plan to user with:
 - Implementation approach (file-level)
 - Gap analysis findings (from Phase 4 synthesis)
@@ -174,6 +218,8 @@ Present plan to user with:
 Use AskUserQuestion for any ambiguous design choices that need user input before proceeding to IMPLEMENT.
 
 ## Phase 8: Persist
+
+**Requires:** PLAN_OUTPUT
 
 If the plan is substantial (>10 implementation steps or HIGH/CRITICAL context risk):
 - Write to `.docs/design/{topic-slug}.{YYYY-MM-DD_HHMM}.md` with YAML frontmatter
@@ -196,3 +242,20 @@ Structured plan ready to feed into IMPLEMENT/ORCHESTRATED if user proceeds:
 - Risks and mitigations
 - Open questions (if any)
 - Design artifact path (if written to disk)
+
+## Phase Completion Checklist
+
+Before presenting output, verify every phase was announced:
+
+- [ ] Phase 0: Load Knowledge Index → KNOWLEDGE_CONTEXT captured
+- [ ] Phase 0.5: Requirements Discovery → CONSTRAINED_PROBLEM captured (or skipped with stated reason)
+- [ ] Phase 1: Orient → ORIENT_OUTPUT captured
+- [ ] Phase 2: Explore → EXPLORE_OUTPUT captured
+- [ ] Phase 3: Gap Analysis Lite → GAP_OUTPUT captured
+- [ ] Phase 4: Synthesize → SYNTHESIS_OUTPUT captured
+- [ ] Phase 5: Plan → PLAN_OUTPUT captured
+- [ ] Phase 6: Design Review Lite → REVIEW_NOTES captured
+- [ ] Phase 7: Present → Output delivered to user
+- [ ] Phase 8: Persist → Artifact written (or skipped with stated reason)
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/resolve:orch/SKILL.md
+++ b/shared/skills/resolve:orch/SKILL.md
@@ -22,6 +22,8 @@ This is a lightweight variant of `/resolve` for ambient mode. Excluded: pitfall 
 
 ## Phase 1: Target Review Directory
 
+**Produces:** REVIEW_DIR, BRANCH_SLUG
+
 Find the latest timestamped directory under `.docs/reviews/` that:
 1. Contains a `review-summary.md` (has been reviewed)
 2. Does NOT contain a `resolution-summary.md` (hasn't been resolved yet)
@@ -35,9 +37,15 @@ Extract branch slug from the directory path.
      handled by Phase 1 here). Same content as resolve.md Step 0d. -->
 ## Phase 1.5: Load Project Knowledge
 
+**Produces:** KNOWLEDGE_CONTEXT
+**Requires:** REVIEW_DIR
+
 Run `node scripts/hooks/lib/knowledge-context.cjs index "{worktree}"` to produce a compact index of active ADR/PF entries from `decisions.md` and `pitfalls.md`, with Deprecated/Superseded entries already stripped. Falls back to `(none)` when both files are absent or all entries are filtered. Pass `KNOWLEDGE_CONTEXT` to every Resolver agent in Phase 4. Resolver agents use `devflow:apply-knowledge` to Read full entry bodies on demand — no fan-out of the full corpus.
 
 ## Phase 2: Parse Issues
+
+**Produces:** ISSUES
+**Requires:** REVIEW_DIR
 
 Read all `{focus}.md` files in the timestamped directory (exclude `review-summary.md` and `resolution-summary.md`).
 
@@ -49,6 +57,9 @@ If no actionable issues found: "Review is clean — no issues to resolve." → s
 
 ## Phase 3: Analyze & Batch
 
+**Produces:** BATCHES
+**Requires:** ISSUES
+
 Group issues by file/function for efficient resolution:
 - Issues in the same file → same batch
 - Issues with cross-file dependencies → same batch
@@ -57,6 +68,9 @@ Group issues by file/function for efficient resolution:
 Determine execution: batches with no shared files can run in parallel.
 
 ## Phase 4: Resolve (Parallel)
+
+**Produces:** RESOLUTION_RESULTS
+**Requires:** BATCHES, KNOWLEDGE_CONTEXT, BRANCH_SLUG
 
 Spawn `Agent(subagent_type="Resolver")` agents — one per batch, parallel where possible.
 
@@ -73,12 +87,17 @@ Resolvers follow a 3-tier risk approach:
 
 ## Phase 5: Collect & Simplify
 
+**Produces:** SIMPLIFICATION_RESULTS
+**Requires:** RESOLUTION_RESULTS
+
 Aggregate results from all Resolver agents:
 - Count: fixed, false positives, deferred
 
 Spawn `Agent(subagent_type="Simplifier")` on all files modified by Resolvers.
 
 ## Phase 6: Report
+
+**Requires:** RESOLUTION_RESULTS, SIMPLIFICATION_RESULTS, REVIEW_DIR
 
 Write `resolution-summary.md` to the same timestamped review directory.
 
@@ -97,3 +116,17 @@ Report to user:
 - **All issues false positive**: Report findings, write resolution-summary noting no changes needed
 - **Resolver BLOCKED**: Report which batch blocked, continue with remaining
 - **Simplifier fails**: Resolution still valid — report that simplification was skipped
+
+## Phase Completion Checklist
+
+Before reporting results, verify every phase was announced:
+
+- [ ] Phase 1: Target Review Directory → REVIEW_DIR captured
+- [ ] Phase 1.5: Load Project Knowledge → KNOWLEDGE_CONTEXT captured
+- [ ] Phase 2: Parse Issues → ISSUES captured (or stopped: no actionable issues)
+- [ ] Phase 3: Analyze & Batch → BATCHES captured
+- [ ] Phase 4: Resolve → RESOLUTION_RESULTS captured per batch
+- [ ] Phase 5: Collect & Simplify → SIMPLIFICATION_RESULTS captured
+- [ ] Phase 6: Report → resolution-summary.md written
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/review:orch/SKILL.md
+++ b/shared/skills/review:orch/SKILL.md
@@ -19,7 +19,11 @@ This is a lightweight variant of `/code-review` for ambient ORCHESTRATED mode. E
 
 ---
 
+**Continuation**: Phase 2 handles incremental detection via `.last-review-head` — no separate continuation path needed.
+
 ## Phase 1: Pre-flight
+
+**Produces:** BRANCH_INFO, PR_INFO
 
 Spawn `Agent(subagent_type="Git")` with action `ensure-pr-ready`:
 - Extract: branch, base_branch, branch_slug, pr_number
@@ -28,6 +32,9 @@ Spawn `Agent(subagent_type="Git")` with action `ensure-pr-ready`:
 Determine base branch: use PR target if PR exists, otherwise `main`/`master`.
 
 ## Phase 2: Incremental Detection
+
+**Produces:** DIFF_RANGE, REVIEW_DIR, TIMESTAMP
+**Requires:** BRANCH_INFO
 
 Check `.docs/reviews/{branch_slug}/.last-review-head`:
 - If file exists and SHA matches HEAD: "No new commits since last review. Nothing to do." → stop
@@ -39,6 +46,9 @@ Create directory: `mkdir -p .docs/reviews/{branch_slug}/{timestamp}`
 
 ## Phase 2b: Load Knowledge Index
 
+**Produces:** KNOWLEDGE_CONTEXT
+**Requires:** REVIEW_DIR
+
 After incremental detection, load the knowledge index:
 
 ```bash
@@ -48,6 +58,9 @@ KNOWLEDGE_CONTEXT=$(node scripts/hooks/lib/knowledge-context.cjs index "{worktre
 This produces a compact index of active ADR/PF entries. Pass `KNOWLEDGE_CONTEXT` to all Reviewer agents. Reviewers use `devflow:apply-knowledge` to Read full entry bodies on demand.
 
 ## Phase 3: File Analysis
+
+**Produces:** REVIEWER_LIST
+**Requires:** DIFF_RANGE
 
 Run `git diff --name-only {DIFF_RANGE}` to get changed files.
 
@@ -69,6 +82,9 @@ Detect conditional reviewers from file types:
 
 ## Phase 4: Reviews (Parallel)
 
+**Produces:** REVIEWER_OUTPUTS
+**Requires:** DIFF_RANGE, REVIEW_DIR, TIMESTAMP, KNOWLEDGE_CONTEXT, REVIEWER_LIST
+
 Spawn all reviewers in a single message (parallel execution):
 
 **7 core reviewers** (always):
@@ -86,12 +102,16 @@ Each reviewer receives:
 
 ## Phase 5: Synthesis (Parallel)
 
+**Requires:** REVIEWER_OUTPUTS, REVIEW_DIR, PR_INFO
+
 After all reviewers complete, spawn in parallel:
 
 1. `Agent(subagent_type="Git")` with action `comment-pr` — post review summary as PR comment (deduplicate: check existing comments first)
 2. `Agent(subagent_type="Synthesizer")` in review mode — reads all `{focus}.md` files from disk, writes `review-summary.md`
 
 ## Phase 6: Finalize
+
+**Requires:** BRANCH_INFO, REVIEW_DIR
 
 Write HEAD SHA to `.docs/reviews/{branch_slug}/.last-review-head` for next incremental review.
 
@@ -107,3 +127,17 @@ Report to user:
 - **No changed files**: "No changes to review." → stop
 - **Reviewer fails**: Report which reviewer failed, continue with remaining
 - **Synthesizer fails**: Reports are still on disk — user can read them directly
+
+## Phase Completion Checklist
+
+Before reporting results, verify every phase was announced:
+
+- [ ] Phase 1: Pre-flight → BRANCH_INFO, PR_INFO captured
+- [ ] Phase 2: Incremental Detection → DIFF_RANGE, REVIEW_DIR, TIMESTAMP captured
+- [ ] Phase 2b: Load Knowledge Index → KNOWLEDGE_CONTEXT captured
+- [ ] Phase 3: File Analysis → REVIEWER_LIST captured
+- [ ] Phase 4: Reviews → REVIEWER_OUTPUTS written to disk
+- [ ] Phase 5: Synthesis → review-summary.md written
+- [ ] Phase 6: Finalize → .last-review-head updated, results reported
+
+If any phase is unchecked, execute it before proceeding.

--- a/shared/skills/router/SKILL.md
+++ b/shared/skills/router/SKILL.md
@@ -13,6 +13,16 @@ GUIDED: work directly in main session. Spawn Simplifier after code changes.
 - GUIDED PLAN: spawn Skimmer for orientation, then plan directly.
 ORCHESTRATED: follow the loaded orchestration skill's pipeline.
 
+## Phase Protocol
+
+All ORCHESTRATED pipelines follow this protocol:
+
+1. **Announce** — Before executing each phase, output: `Phase N: {name}`. No phase may execute without this announcement. Skipping the announcement and doing the work anyway is a protocol violation.
+2. **Produce** — Each phase declares what it `Produces:`. Capture that output by name. Subsequent phases reference it via `Requires:`.
+3. **No silent skips** — If a phase's preconditions are not met (e.g., no issues found), announce the phase, state why it is being skipped, and move to the next phase. The announcement must still appear.
+4. **Verify** — Before presenting final output, check the skill's Phase Completion Checklist. Every phase must show as announced. If any phase was missed, execute it before proceeding.
+5. **Scoped nesting** — When a pipeline delegates to another orchestration skill (e.g., pipeline:orch → implement:orch), the inner skill's phases use a scoped prefix: `{Outer} > Phase N: {name}` (e.g., `Implement > Phase 1: Pre-flight`).
+
 ## GUIDED
 
 | Intent | Skills |

--- a/tests/ambient.test.ts
+++ b/tests/ambient.test.ts
@@ -784,3 +784,72 @@ describe('phase protocol structural validation', () => {
     }
   });
 });
+
+describe('command Produces/Requires validation', () => {
+  const pluginsDir = path.resolve(__dirname, '../plugins');
+
+  async function discoverCommandFiles(): Promise<string[]> {
+    const plugins = await fs.readdir(pluginsDir);
+    const files: string[] = [];
+    for (const plugin of plugins) {
+      const cmdDir = path.join(pluginsDir, plugin, 'commands');
+      try {
+        const entries = await fs.readdir(cmdDir);
+        for (const f of entries) {
+          if (f.endsWith('.md')) files.push(path.join(cmdDir, f));
+        }
+      } catch { /* no commands dir */ }
+    }
+    return files.sort();
+  }
+
+  it('every command file has Produces: annotations', async () => {
+    for (const file of await discoverCommandFiles()) {
+      const content = await fs.readFile(file, 'utf-8');
+      const name = path.relative(pluginsDir, file);
+      expect(content, `${name} missing Produces:`).toContain('**Produces:**');
+    }
+  });
+
+  it('every command file has Requires: annotations', async () => {
+    for (const file of await discoverCommandFiles()) {
+      const content = await fs.readFile(file, 'utf-8');
+      const name = path.relative(pluginsDir, file);
+      expect(content, `${name} missing Requires:`).toContain('**Requires:**');
+    }
+  });
+
+  it('every phase/step heading is followed by a Produces or Requires annotation', async () => {
+    const headingPattern = /^#{2,4}\s+(Phase|Step)\s+\d/;
+
+    for (const file of await discoverCommandFiles()) {
+      const content = await fs.readFile(file, 'utf-8');
+      const name = path.relative(pluginsDir, file);
+      const lines = content.split('\n');
+
+      const headingIndices: number[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        if (headingPattern.test(lines[i])) headingIndices.push(i);
+      }
+
+      for (let h = 0; h < headingIndices.length; h++) {
+        const idx = headingIndices[h];
+        const currentLevel = (lines[idx].match(/^(#+)/) ?? ['', ''])[1].length;
+
+        // Skip container headings (next heading is deeper level = substeps)
+        if (h + 1 < headingIndices.length) {
+          const nextLevel = (lines[headingIndices[h + 1]].match(/^(#+)/) ?? ['', ''])[1].length;
+          if (nextLevel > currentLevel) continue;
+        }
+
+        const endIdx = h + 1 < headingIndices.length ? headingIndices[h + 1] : lines.length;
+        const body = lines.slice(idx + 1, endIdx).join('\n');
+
+        expect(
+          body.includes('**Produces:**') || body.includes('**Requires:**'),
+          `${name}: "${lines[idx].trim()}" missing Produces/Requires annotation`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/ambient.test.ts
+++ b/tests/ambient.test.ts
@@ -709,20 +709,15 @@ describe('preamble drift detection', () => {
 });
 
 describe('phase protocol structural validation', () => {
-  const orchSkills = [
-    'plan:orch',
-    'implement:orch',
-    'review:orch',
-    'resolve:orch',
-    'debug:orch',
-    'explore:orch',
-    'pipeline:orch',
-  ];
-
   const sharedSkillsDir = path.resolve(__dirname, '../shared/skills');
 
+  async function discoverOrchSkills(): Promise<string[]> {
+    const entries = await fs.readdir(sharedSkillsDir);
+    return entries.filter(e => e.endsWith(':orch')).sort();
+  }
+
   it('every orch skill has a Phase Completion Checklist', async () => {
-    for (const skill of orchSkills) {
+    for (const skill of await discoverOrchSkills()) {
       const content = await fs.readFile(
         path.join(sharedSkillsDir, skill, 'SKILL.md'),
         'utf-8',
@@ -734,7 +729,7 @@ describe('phase protocol structural validation', () => {
   });
 
   it('every orch skill has Produces: annotations', async () => {
-    for (const skill of orchSkills) {
+    for (const skill of await discoverOrchSkills()) {
       const content = await fs.readFile(
         path.join(sharedSkillsDir, skill, 'SKILL.md'),
         'utf-8',
@@ -746,7 +741,7 @@ describe('phase protocol structural validation', () => {
   });
 
   it('every orch skill has Requires: annotations', async () => {
-    for (const skill of orchSkills) {
+    for (const skill of await discoverOrchSkills()) {
       const content = await fs.readFile(
         path.join(sharedSkillsDir, skill, 'SKILL.md'),
         'utf-8',
@@ -770,7 +765,7 @@ describe('phase protocol structural validation', () => {
   });
 
   it('checklist item count matches phase count in each orch skill', async () => {
-    for (const skill of orchSkills) {
+    for (const skill of await discoverOrchSkills()) {
       const content = await fs.readFile(
         path.join(sharedSkillsDir, skill, 'SKILL.md'),
         'utf-8',

--- a/tests/ambient.test.ts
+++ b/tests/ambient.test.ts
@@ -787,6 +787,11 @@ describe('phase protocol structural validation', () => {
 
 describe('command Produces/Requires validation', () => {
   const pluginsDir = path.resolve(__dirname, '../plugins');
+  const phaseStepPattern = /^#{2,4}\s+(Phase|Step)\s+\d/;
+
+  function headingLevel(line: string): number {
+    return (line.match(/^(#+)/) ?? ['', ''])[1].length;
+  }
 
   async function discoverCommandFiles(): Promise<string[]> {
     const plugins = await fs.readdir(pluginsDir);
@@ -820,8 +825,6 @@ describe('command Produces/Requires validation', () => {
   });
 
   it('every phase/step heading is followed by a Produces or Requires annotation', async () => {
-    const headingPattern = /^#{2,4}\s+(Phase|Step)\s+\d/;
-
     for (const file of await discoverCommandFiles()) {
       const content = await fs.readFile(file, 'utf-8');
       const name = path.relative(pluginsDir, file);
@@ -829,17 +832,16 @@ describe('command Produces/Requires validation', () => {
 
       const headingIndices: number[] = [];
       for (let i = 0; i < lines.length; i++) {
-        if (headingPattern.test(lines[i])) headingIndices.push(i);
+        if (phaseStepPattern.test(lines[i])) headingIndices.push(i);
       }
 
       for (let h = 0; h < headingIndices.length; h++) {
         const idx = headingIndices[h];
-        const currentLevel = (lines[idx].match(/^(#+)/) ?? ['', ''])[1].length;
+        const currentLevel = headingLevel(lines[idx]);
 
         // Skip container headings (next heading is deeper level = substeps)
         if (h + 1 < headingIndices.length) {
-          const nextLevel = (lines[headingIndices[h + 1]].match(/^(#+)/) ?? ['', ''])[1].length;
-          if (nextLevel > currentLevel) continue;
+          if (headingLevel(lines[headingIndices[h + 1]]) > currentLevel) continue;
         }
 
         const endIdx = h + 1 < headingIndices.length ? headingIndices[h + 1] : lines.length;

--- a/tests/ambient.test.ts
+++ b/tests/ambient.test.ts
@@ -693,6 +693,11 @@ describe('preamble drift detection', () => {
     expect(routerContent).toContain('DEBUG');
     expect(routerContent).toContain('PLAN');
     expect(routerContent).toContain('REVIEW');
+
+    // Must contain Phase Protocol section
+    expect(routerContent).toContain('## Phase Protocol');
+    expect(routerContent).toContain('Announce');
+    expect(routerContent).toContain('No silent skips');
   });
 
   it('session-start-classification hook reads classification-rules.md', async () => {
@@ -700,5 +705,87 @@ describe('preamble drift detection', () => {
     const hookContent = await fs.readFile(hookPath, 'utf-8');
 
     expect(hookContent).toContain('classification-rules.md');
+  });
+});
+
+describe('phase protocol structural validation', () => {
+  const orchSkills = [
+    'plan:orch',
+    'implement:orch',
+    'review:orch',
+    'resolve:orch',
+    'debug:orch',
+    'explore:orch',
+    'pipeline:orch',
+  ];
+
+  const sharedSkillsDir = path.resolve(__dirname, '../shared/skills');
+
+  it('every orch skill has a Phase Completion Checklist', async () => {
+    for (const skill of orchSkills) {
+      const content = await fs.readFile(
+        path.join(sharedSkillsDir, skill, 'SKILL.md'),
+        'utf-8',
+      );
+      expect(content, `${skill} missing Phase Completion Checklist`).toContain(
+        '## Phase Completion Checklist',
+      );
+    }
+  });
+
+  it('every orch skill has Produces: annotations', async () => {
+    for (const skill of orchSkills) {
+      const content = await fs.readFile(
+        path.join(sharedSkillsDir, skill, 'SKILL.md'),
+        'utf-8',
+      );
+      expect(content, `${skill} missing Produces: annotations`).toContain(
+        '**Produces:**',
+      );
+    }
+  });
+
+  it('every orch skill has Requires: annotations', async () => {
+    for (const skill of orchSkills) {
+      const content = await fs.readFile(
+        path.join(sharedSkillsDir, skill, 'SKILL.md'),
+        'utf-8',
+      );
+      expect(content, `${skill} missing Requires: annotations`).toContain(
+        '**Requires:**',
+      );
+    }
+  });
+
+  it('plan:orch and implement:orch have Continuation Detection', async () => {
+    for (const skill of ['plan:orch', 'implement:orch']) {
+      const content = await fs.readFile(
+        path.join(sharedSkillsDir, skill, 'SKILL.md'),
+        'utf-8',
+      );
+      expect(content, `${skill} missing Continuation Detection`).toContain(
+        '## Continuation Detection',
+      );
+    }
+  });
+
+  it('checklist item count matches phase count in each orch skill', async () => {
+    for (const skill of orchSkills) {
+      const content = await fs.readFile(
+        path.join(sharedSkillsDir, skill, 'SKILL.md'),
+        'utf-8',
+      );
+
+      // Count phase headings (## Phase N or ### Phase N — digit distinguishes from ## Phase Completion Checklist)
+      const phaseHeadings = content.match(/^#{2,3}\s+Phase\s+\d/gm) ?? [];
+
+      // Count checklist items (- [ ] Phase)
+      const checklistItems = content.match(/^- \[ \] Phase/gm) ?? [];
+
+      expect(
+        checklistItems.length,
+        `${skill}: ${checklistItems.length} checklist items but ${phaseHeadings.length} phases`,
+      ).toBe(phaseHeadings.length);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add **Phase Protocol** section to `router/SKILL.md` with 5 universal enforcement rules (announce, produce, no silent skips, verify, scoped nesting)
- Add **`Produces:`/`Requires:` checkpoint variables** to all 7 orchestration skills, creating data-flow dependencies between phases
- Add **Continuation Detection** to `plan:orch` (refinement path for existing artifacts) and `implement:orch` (re-validation path after manual fixes)
- Add **Phase Completion Checklist** to all 7 orchestration skills as a final self-check gate
- Add **scoped nesting** note to `pipeline:orch` for inner skill phase prefix format
- Add **5 structural tests** validating checklist/phase count correspondence, annotation presence, and continuation detection placement

All changes are markdown-only (SKILL.md files) + test additions. No TypeScript CLI code changes.

## Test plan

- [x] `npm run build` succeeds — skills distributed to all 17 plugins
- [x] `npm test` passes — 1064/1064 tests (0 failures)
- [x] New `phase protocol structural validation` test suite passes all 5 assertions
- [x] Existing router/classification/preamble drift tests unaffected
- [ ] Manual: `devflow init` reinstalls updated skills
- [ ] Manual: trigger PLAN/ORCHESTRATED — verify model announces phases
- [ ] Manual: trigger with existing `.docs/design/` artifact — verify continuation detection