### PR TITLE
refactor: simplify rules helpers, update CLI reference

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,6 +22,9 @@ Use `--recommended` or `--advanced` flags for non-interactive setup.
 | `--ambient` / `--no-ambient` | Enable/disable ambient mode (default: on) |
 | `--memory` / `--no-memory` | Enable/disable working memory (default: on) |
 | `--learn` / `--no-learn` | Enable/disable self-learning (default: on) |
+| `--decisions` / `--no-decisions` | Enable/disable decisions agent (default: on) |
+| `--knowledge` / `--no-knowledge` | Enable/disable feature knowledge (default: on) |
+| `--rules` / `--no-rules` | Enable/disable rules (default: on) |
 | `--hud` / `--no-hud` | Enable/disable HUD status line (default: on) |
 | `--hud-only` | Install only the HUD (no plugins, hooks, or extras) |
 | `--verbose` | Show detailed output |
@@ -80,6 +83,42 @@ npx devflow-kit learn --clear        # Reset all observations
 npx devflow-kit learn --purge        # Remove invalid/corrupted entries
 ```
 
+## Decisions
+
+```bash
+npx devflow-kit decisions --enable     # Register the decisions hook
+npx devflow-kit decisions --disable    # Remove the decisions hook
+npx devflow-kit decisions --status     # Show status and entry counts
+npx devflow-kit decisions list         # List all decisions and pitfalls
+npx devflow-kit decisions --configure  # Interactive config (model, throttle)
+npx devflow-kit decisions --review     # Review observations or capacity
+npx devflow-kit decisions --purge      # Remove invalid entries
+npx devflow-kit decisions --clear      # Reset all observations
+npx devflow-kit decisions --reset      # Remove all artifacts + log
+```
+
+## Feature Knowledge
+
+```bash
+npx devflow-kit knowledge list              # List knowledge bases with staleness
+npx devflow-kit knowledge create <slug>     # Create a new knowledge base
+npx devflow-kit knowledge check             # Check all for staleness
+npx devflow-kit knowledge refresh [slug]    # Refresh stale knowledge base(s)
+npx devflow-kit knowledge remove <slug>     # Remove a knowledge base
+npx devflow-kit knowledge --enable          # Enable feature knowledge
+npx devflow-kit knowledge --disable         # Disable feature knowledge
+npx devflow-kit knowledge --status          # Show current status
+```
+
+## Rules
+
+```bash
+npx devflow-kit rules --enable       # Install rules from manifest plugins
+npx devflow-kit rules --disable      # Remove all installed rules
+npx devflow-kit rules --status       # Show installed rules with source plugin
+npx devflow-kit rules --list         # Show all available rules with install status
+```
+
 ## HUD (Status Line)
 
 ```bash
@@ -99,6 +138,15 @@ npx devflow-kit skills shadow software-design    # Create override (copies curre
 vim ~/.devflow/skills/software-design/SKILL.md   # Edit your override
 npx devflow-kit skills list-shadowed             # List all overrides
 npx devflow-kit skills unshadow software-design  # Remove override
+```
+
+## Feature Flags
+
+```bash
+npx devflow-kit flags --list           # List all flags with current state
+npx devflow-kit flags --enable <flag>  # Enable a flag
+npx devflow-kit flags --disable <flag> # Disable a flag
+npx devflow-kit flags --status         # Show enabled flags
 ```
 
 ## Uninstall

--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -30,18 +30,13 @@ async function isShadowed(devflowDir: string, ruleName: string): Promise<boolean
   }
 }
 
-/** Reverse map of all rule names to their owning plugin (lazily computed once). */
-const allRulesMap = buildRulesMap(DEVFLOW_PLUGINS);
-
-/**
- * Format a single rule row with owner attribution and shadow tag.
- */
 async function formatRuleRow(
   name: string,
   devflowDir: string,
+  ownerMap: Map<string, string>,
   suffix: string,
 ): Promise<string> {
-  const owner = allRulesMap.get(name) ?? 'unknown';
+  const owner = ownerMap.get(name) ?? 'unknown';
   const shortOwner = owner.replace('devflow-', '');
   const shadowTag = await isShadowed(devflowDir, name) ? color.yellow(' [shadowed]') : '';
   return `  ${color.cyan(name.padEnd(16))} ${color.dim(shortOwner)}${suffix}${shadowTag}`;
@@ -108,8 +103,9 @@ export const rulesCommand = new Command('rules')
         return;
       }
 
+      const ownerMap = buildRulesMap(DEVFLOW_PLUGINS);
       const lines = await Promise.all(
-        installedFiles.map(file => formatRuleRow(path.basename(file, '.md'), devflowDir, '')),
+        installedFiles.map(file => formatRuleRow(path.basename(file, '.md'), devflowDir, ownerMap, '')),
       );
       p.note(lines.join('\n'), `Installed rules (${installedFiles.length})`);
 
@@ -122,10 +118,11 @@ export const rulesCommand = new Command('rules')
       } catch { /* dir doesn't exist */ }
       const installedSet = new Set(installedNames);
 
+      const ownerMap = buildRulesMap(DEVFLOW_PLUGINS);
       const lines = await Promise.all(
         allRules.map(name => {
           const tag = installedSet.has(name) ? color.green(' ✓') : color.dim(' ✗');
-          return formatRuleRow(name, devflowDir, tag);
+          return formatRuleRow(name, devflowDir, ownerMap, tag);
         }),
       );
       p.note(lines.join('\n'), `Available rules (${allRules.length})`);

--- a/src/cli/utils/installer.ts
+++ b/src/cli/utils/installer.ts
@@ -5,15 +5,6 @@ import type { PluginDefinition } from '../plugins.js';
 import { DEVFLOW_PLUGINS, LEGACY_AGENT_NAMES, prefixSkillName } from '../plugins.js';
 
 /**
- * Validate a rule name: only lowercase letters, digits, and hyphens.
- * Defense-in-depth guard — rule names come from static plugin config but
- * this prevents path traversal if the source ever includes user input.
- */
-export function isValidRuleName(name: string): boolean {
-  return /^[a-z0-9-]+$/.test(name);
-}
-
-/**
  * Install a single rule file, respecting the shadow override at
  * ~/.devflow/rules/{name}.md over the built plugin source.
  * Skips silently if the source file does not exist (missing build artifact).
@@ -28,21 +19,17 @@ export async function installRuleFile(
   const shadowFile = path.join(devflowDir, 'rules', `${ruleName}.md`);
   const targetFile = path.join(rulesTarget, `${ruleName}.md`);
 
-  let useShadow = false;
   try {
     await fs.access(shadowFile);
-    useShadow = true;
-  } catch { /* no shadow */ }
-
-  if (useShadow) {
     await fs.copyFile(shadowFile, targetFile);
-  } else {
-    const ruleSource = path.join(pluginsDir, ownerPlugin, 'rules', `${ruleName}.md`);
-    try {
-      await fs.access(ruleSource);
-      await fs.copyFile(ruleSource, targetFile);
-    } catch { /* source missing — skip */ }
-  }
+    return;
+  } catch { /* no shadow — fall through to plugin source */ }
+
+  const ruleSource = path.join(pluginsDir, ownerPlugin, 'rules', `${ruleName}.md`);
+  try {
+    await fs.access(ruleSource);
+    await fs.copyFile(ruleSource, targetFile);
+  } catch { /* source missing — skip */ }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove module-level `allRulesMap` singleton from rules.ts — `formatRuleRow` now takes explicit `ownerMap` parameter
- Simplify `installRuleFile` control flow (shadow-first try/return pattern)
- Remove duplicate `isValidRuleName` from installer.ts (canonical version is in plugins.ts)
- Add missing CLI reference docs: `devflow decisions`, `devflow knowledge`, `devflow rules`, `devflow flags` commands and `--decisions/--knowledge/--rules` init flags

Follow-up to PR #213 (rules system).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1411 tests pass