### PR TITLE
feat(init): simplify init flow — scope removal, two-step plugin selection, /bug-analysis in WORKFLOW_ORDER

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -121,6 +121,34 @@ export function parsePluginSelection(
 }
 
 /**
+ * Combine workflow and language selections into a single plugin list.
+ * Returns the merged array and whether a valid (non-empty) selection was made.
+ *
+ * Pure function — no I/O, no side effects; extracted for testability.
+ */
+export function combineSelection(
+  workflowSelected: string[],
+  languageSelected: string[],
+): { plugins: string[]; accepted: boolean } {
+  const plugins = [...workflowSelected, ...languageSelected];
+  return { plugins, accepted: plugins.length > 0 };
+}
+
+/**
+ * Decide whether the selection loop should retry on the next iteration.
+ *
+ * Returns true when a retry is warranted (selection was empty and attempts
+ * have not been exhausted). Returns false when either the selection is
+ * accepted or the attempt ceiling has been reached (caller should exit).
+ *
+ * Pure function — no I/O, no side effects; extracted for testability.
+ */
+export function shouldRetry(attempt: number, maxAttempts: number, accepted: boolean): boolean {
+  if (accepted) return false;
+  return attempt < maxAttempts;
+}
+
+/**
  * Options for the init command parsed by Commander.js
  */
 interface InitOptions {
@@ -289,8 +317,8 @@ export const initCommand = new Command('init')
         'devflow-explore': 'codebase exploration + knowledge bases',
         'devflow-research': 'multi-type research with synthesis',
         'devflow-release': 'adaptive release with learned config',
-        'devflow-bug-analysis': 'proactive bug finding, post-pipeline',
         'devflow-self-review': 'Simplifier + Scrutinizer',
+        'devflow-bug-analysis': 'proactive bug finding, post-pipeline',
         'devflow-typescript': 'TypeScript patterns',
         'devflow-react': 'React patterns',
         'devflow-accessibility': 'WCAG compliance',
@@ -303,17 +331,14 @@ export const initCommand = new Command('init')
 
       const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
 
-      const workflowChoices = workflow.map(pl => ({
+      const toChoice = (pl: PluginDefinition) => ({
         value: pl.name,
         label: pl.name.replace('devflow-', ''),
         hint: pluginHints[pl.name] ?? pl.description,
-      }));
+      });
 
-      const languageChoices = language.map(pl => ({
-        value: pl.name,
-        label: pl.name.replace('devflow-', ''),
-        hint: pluginHints[pl.name] ?? pl.description,
-      }));
+      const workflowChoices = workflow.map(toChoice);
+      const languageChoices = language.map(toChoice);
 
       const workflowInitialValues = workflow
         .filter(pl => !pl.optional)
@@ -339,7 +364,7 @@ export const initCommand = new Command('init')
             p.cancel('Installation cancelled.');
             process.exit(0);
           }
-          workflowSelected = step1 as string[];
+          workflowSelected = step1;
         }
 
         // Step 2 — Language plugins (skip if empty bucket)
@@ -354,22 +379,22 @@ export const initCommand = new Command('init')
             p.cancel('Installation cancelled.');
             process.exit(0);
           }
-          languageSelected = step2 as string[];
+          languageSelected = step2;
         }
 
-        const combined = [...workflowSelected, ...languageSelected];
+        const { plugins: combined, accepted } = combineSelection(workflowSelected, languageSelected);
 
-        if (combined.length > 0) {
+        if (accepted) {
           selectedPlugins = combined;
           break;
         }
 
-        if (attempts < MAX_ATTEMPTS) {
-          p.log.warn('Select at least one plugin.');
-        } else {
+        const isLastAttempt = !shouldRetry(attempts, MAX_ATTEMPTS, accepted);
+        if (isLastAttempt) {
           p.cancel('Installation cancelled — no plugins selected.');
           process.exit(0);
         }
+        p.log.warn('Select at least one plugin.');
       }
     }
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -18,7 +18,7 @@ import {
   createDocsStructure,
   type SecurityMode,
 } from '../utils/post-install.js';
-import { DEVFLOW_PLUGINS, LEGACY_PLUGIN_NAMES, LEGACY_SKILL_NAMES, LEGACY_COMMAND_NAMES, LEGACY_RULE_NAMES, buildAssetMaps, buildFullSkillsMap, buildRulesMap, type PluginDefinition } from '../plugins.js';
+import { DEVFLOW_PLUGINS, LEGACY_PLUGIN_NAMES, LEGACY_SKILL_NAMES, LEGACY_COMMAND_NAMES, LEGACY_RULE_NAMES, buildAssetMaps, buildFullSkillsMap, buildRulesMap, partitionSelectablePlugins, WORKFLOW_ORDER, type PluginDefinition } from '../plugins.js';
 import { detectPlatform, detectShell, getProfilePath, getSafeDeleteInfo, hasSafeDelete } from '../utils/safe-delete.js';
 import { generateSafeDeleteBlock, installToProfile, removeFromProfile, getInstalledVersion, SAFE_DELETE_BLOCK_VERSION } from '../utils/safe-delete-install.js';
 import { addAmbientHook, removeAmbientHook } from './ambient.js';
@@ -196,21 +196,6 @@ export const initCommand = new Command('init')
     } else if (!process.stdin.isTTY) {
       p.log.info('Non-interactive mode detected, using scope: user');
       scope = 'user';
-    } else {
-      const selected = await p.select({
-        message: 'Installation scope',
-        options: [
-          { value: 'user', label: 'User', hint: 'all projects (~/.claude/)' },
-          { value: 'local', label: 'Local', hint: 'this project only (./.claude/)' },
-        ],
-      });
-
-      if (p.isCancel(selected)) {
-        p.cancel('Installation cancelled.');
-        process.exit(0);
-      }
-
-      scope = selected as 'user' | 'local';
     }
 
     // --hud-only: install only HUD (skip plugins, hooks, extras)
@@ -301,6 +286,10 @@ export const initCommand = new Command('init')
         'devflow-code-review': 'parallel specialized reviewers',
         'devflow-resolve': 'fix review issues by risk',
         'devflow-debug': 'competing hypotheses',
+        'devflow-explore': 'codebase exploration + knowledge bases',
+        'devflow-research': 'multi-type research with synthesis',
+        'devflow-release': 'adaptive release with learned config',
+        'devflow-bug-analysis': 'proactive bug finding, post-pipeline',
         'devflow-self-review': 'Simplifier + Scrutinizer',
         'devflow-typescript': 'TypeScript patterns',
         'devflow-react': 'React patterns',
@@ -312,31 +301,80 @@ export const initCommand = new Command('init')
         'devflow-rust': 'Rust patterns',
       };
 
-      const choices = DEVFLOW_PLUGINS
-        .filter(pl => pl.name !== 'devflow-core-skills' && pl.name !== 'devflow-ambient' && pl.name !== 'devflow-audit-claude')
-        .map(pl => ({
-          value: pl.name,
-          label: pl.name.replace('devflow-', ''),
-          hint: pluginHints[pl.name] ?? pl.description,
-        }));
+      const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
 
-      const preSelected = DEVFLOW_PLUGINS
-        .filter(pl => !pl.optional && pl.name !== 'devflow-core-skills' && pl.name !== 'devflow-ambient')
+      const workflowChoices = workflow.map(pl => ({
+        value: pl.name,
+        label: pl.name.replace('devflow-', ''),
+        hint: pluginHints[pl.name] ?? pl.description,
+      }));
+
+      const languageChoices = language.map(pl => ({
+        value: pl.name,
+        label: pl.name.replace('devflow-', ''),
+        hint: pluginHints[pl.name] ?? pl.description,
+      }));
+
+      const workflowInitialValues = workflow
+        .filter(pl => !pl.optional)
         .map(pl => pl.name);
 
-      const pluginSelection = await p.multiselect({
-        message: 'Select plugins to install',
-        options: choices,
-        initialValues: preSelected,
-        required: true,
-      });
+      // Bounded selection loop — max 3 attempts (reliability rule: no unbounded loops)
+      const MAX_ATTEMPTS = 3;
+      let attempts = 0;
 
-      if (p.isCancel(pluginSelection)) {
-        p.cancel('Installation cancelled.');
-        process.exit(0);
+      while (attempts < MAX_ATTEMPTS) {
+        attempts++;
+        const workflowSelected: string[] = [];
+        const languageSelected: string[] = [];
+
+        // Step 1 — Workflow plugins (skip if empty bucket)
+        if (workflowChoices.length > 0) {
+          const step1 = await p.multiselect({
+            message: 'Step 1 — Workflow plugins',
+            options: workflowChoices,
+            initialValues: workflowInitialValues,
+            required: false,
+          });
+
+          if (p.isCancel(step1)) {
+            p.cancel('Installation cancelled.');
+            process.exit(0);
+          }
+
+          workflowSelected.push(...(step1 as string[]));
+        }
+
+        // Step 2 — Language plugins (skip if empty bucket)
+        if (languageChoices.length > 0) {
+          const step2 = await p.multiselect({
+            message: 'Step 2 — Language plugins',
+            options: languageChoices,
+            required: false,
+          });
+
+          if (p.isCancel(step2)) {
+            p.cancel('Installation cancelled.');
+            process.exit(0);
+          }
+
+          languageSelected.push(...(step2 as string[]));
+        }
+
+        const combined = [...workflowSelected, ...languageSelected];
+
+        if (combined.length > 0) {
+          selectedPlugins = combined;
+          break;
+        }
+
+        if (attempts < MAX_ATTEMPTS) {
+          p.log.warn('Select at least one plugin.');
+        } else {
+          p.cancel('Installation cancelled — no plugins selected.');
+          process.exit(0);
+        }
       }
-
-      selectedPlugins = pluginSelection as string[];
     }
 
     // ╭──────────────────────────────────────────────────────────╮
@@ -1219,11 +1257,6 @@ export const initCommand = new Command('init')
       p.log.info('Installed via file copy (Claude CLI not available)');
     }
 
-    const WORKFLOW_ORDER = [
-      '/research', '/explore', '/plan', '/implement',
-      '/code-review', '/resolve', '/self-review',
-      '/debug', '/release', '/audit-claude',
-    ];
     const installedSet = new Set(pluginsToInstall.flatMap(p => p.commands).filter(c => c.length > 0));
     const orderedCommands = WORKFLOW_ORDER.filter(cmd => installedSet.has(cmd));
     if (orderedCommands.length > 0) {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -325,10 +325,9 @@ export const initCommand = new Command('init')
 
       while (attempts < MAX_ATTEMPTS) {
         attempts++;
-        const workflowSelected: string[] = [];
-        const languageSelected: string[] = [];
 
         // Step 1 — Workflow plugins (skip if empty bucket)
+        let workflowSelected: string[] = [];
         if (workflowChoices.length > 0) {
           const step1 = await p.multiselect({
             message: 'Step 1 — Workflow plugins',
@@ -336,29 +335,26 @@ export const initCommand = new Command('init')
             initialValues: workflowInitialValues,
             required: false,
           });
-
           if (p.isCancel(step1)) {
             p.cancel('Installation cancelled.');
             process.exit(0);
           }
-
-          workflowSelected.push(...(step1 as string[]));
+          workflowSelected = step1 as string[];
         }
 
         // Step 2 — Language plugins (skip if empty bucket)
+        let languageSelected: string[] = [];
         if (languageChoices.length > 0) {
           const step2 = await p.multiselect({
             message: 'Step 2 — Language plugins',
             options: languageChoices,
             required: false,
           });
-
           if (p.isCancel(step2)) {
             p.cancel('Installation cancelled.');
             process.exit(0);
           }
-
-          languageSelected.push(...(step2 as string[]));
+          languageSelected = step2 as string[];
         }
 
         const combined = [...workflowSelected, ...languageSelected];

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -135,11 +135,9 @@ export function combineSelection(
 }
 
 /**
- * Decide whether the selection loop should retry on the next iteration.
- *
- * Returns true when a retry is warranted (selection was empty and attempts
- * have not been exhausted). Returns false when either the selection is
- * accepted or the attempt ceiling has been reached (caller should exit).
+ * Returns true when the selection loop should retry: selection was empty and
+ * the attempt ceiling has not been reached. Returns false when accepted or
+ * when attempts are exhausted (caller should exit).
  *
  * Pure function — no I/O, no side effects; extracted for testability.
  */
@@ -389,8 +387,7 @@ export const initCommand = new Command('init')
           break;
         }
 
-        const isLastAttempt = !shouldRetry(attempts, MAX_ATTEMPTS, accepted);
-        if (isLastAttempt) {
+        if (!shouldRetry(attempts, MAX_ATTEMPTS, accepted)) {
           p.cancel('Installation cancelled — no plugins selected.');
           process.exit(0);
         }

--- a/src/cli/plugins.ts
+++ b/src/cli/plugins.ts
@@ -729,6 +729,10 @@ export function partitionSelectablePlugins(plugins: PluginDefinition[]): {
     if (plugin.commands.length > 0) {
       workflow.push(plugin);
     } else {
+      // "language" bucket: today every command-less selectable plugin is a
+      // language/ecosystem plugin. If a non-language command-less plugin is
+      // added in the future, it will land here — update the bucket name or
+      // add an explicit category field at that point.
       language.push(plugin);
     }
   }

--- a/src/cli/plugins.ts
+++ b/src/cli/plugins.ts
@@ -691,3 +691,47 @@ export function buildRulesMap(plugins: PluginDefinition[]): Map<string, string> 
  * Pruning: entries can be removed after 2 major versions.
  */
 export const LEGACY_RULE_NAMES: string[] = [];
+
+/**
+ * Canonical display order for workflow commands shown at end of init.
+ * Mirrors the user-facing pipeline: research → explore → plan → implement →
+ * code-review → resolve → self-review → bug-analysis → debug → release → audit-claude.
+ * Export so init.ts can import it rather than keeping a local copy.
+ */
+export const WORKFLOW_ORDER: string[] = [
+  '/research', '/explore', '/plan', '/implement',
+  '/code-review', '/resolve', '/self-review', '/bug-analysis',
+  '/debug', '/release', '/audit-claude',
+];
+
+/**
+ * Partition the selectable plugins into workflow (command-bearing) and language
+ * (command-less, optional language/ecosystem) buckets for the two-step init UI.
+ *
+ * Excluded from both buckets (not selectable at init):
+ *   - devflow-core-skills  (always installed)
+ *   - devflow-ambient      (always installed)
+ *   - devflow-audit-claude (installable via --plugin only)
+ *
+ * Pure function — does not mutate the input array; preserves DEVFLOW_PLUGINS
+ * ordering within each bucket; deterministic; no I/O.
+ */
+export function partitionSelectablePlugins(plugins: PluginDefinition[]): {
+  workflow: PluginDefinition[];
+  language: PluginDefinition[];
+} {
+  const EXCLUDED = new Set(['devflow-core-skills', 'devflow-ambient', 'devflow-audit-claude']);
+  const workflow: PluginDefinition[] = [];
+  const language: PluginDefinition[] = [];
+
+  for (const plugin of plugins) {
+    if (EXCLUDED.has(plugin.name)) continue;
+    if (plugin.commands.length > 0) {
+      workflow.push(plugin);
+    } else {
+      language.push(plugin);
+    }
+  }
+
+  return { workflow, language };
+}

--- a/tests/init-logic.test.ts
+++ b/tests/init-logic.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import * as os from 'os';
 import {
   parsePluginSelection,
+  combineSelection,
+  shouldRetry,
   substituteSettingsTemplate,
   computeGitignoreAppend,
   applyTeamsConfig,
@@ -71,6 +73,60 @@ describe('parsePluginSelection', () => {
     const { selected, invalid } = parsePluginSelection('devflow-frontend-design', DEVFLOW_PLUGINS);
     expect(selected).toEqual(['devflow-ui-design']);
     expect(invalid).toEqual([]);
+  });
+});
+
+describe('combineSelection', () => {
+  it('accepts non-empty workflow-only selection', () => {
+    const result = combineSelection(['devflow-implement'], []);
+    expect(result.plugins).toEqual(['devflow-implement']);
+    expect(result.accepted).toBe(true);
+  });
+
+  it('accepts non-empty language-only selection', () => {
+    const result = combineSelection([], ['devflow-typescript']);
+    expect(result.plugins).toEqual(['devflow-typescript']);
+    expect(result.accepted).toBe(true);
+  });
+
+  it('accepts non-empty combined selection from both buckets', () => {
+    const result = combineSelection(['devflow-implement'], ['devflow-typescript']);
+    expect(result.plugins).toEqual(['devflow-implement', 'devflow-typescript']);
+    expect(result.accepted).toBe(true);
+  });
+
+  it('rejects empty-both-buckets selection', () => {
+    const result = combineSelection([], []);
+    expect(result.plugins).toEqual([]);
+    expect(result.accepted).toBe(false);
+  });
+
+  it('workflow entries precede language entries in the merged list', () => {
+    const result = combineSelection(['devflow-implement', 'devflow-code-review'], ['devflow-typescript']);
+    expect(result.plugins).toEqual(['devflow-implement', 'devflow-code-review', 'devflow-typescript']);
+  });
+});
+
+describe('shouldRetry', () => {
+  const MAX_ATTEMPTS = 3;
+
+  it('returns false when selection is accepted (regardless of attempt count)', () => {
+    expect(shouldRetry(1, MAX_ATTEMPTS, true)).toBe(false);
+    expect(shouldRetry(2, MAX_ATTEMPTS, true)).toBe(false);
+    expect(shouldRetry(3, MAX_ATTEMPTS, true)).toBe(false);
+  });
+
+  it('returns true when not accepted and attempts remain', () => {
+    expect(shouldRetry(1, MAX_ATTEMPTS, false)).toBe(true);
+    expect(shouldRetry(2, MAX_ATTEMPTS, false)).toBe(true);
+  });
+
+  it('returns false when not accepted and attempt ceiling is reached (exits instead of retrying)', () => {
+    expect(shouldRetry(3, MAX_ATTEMPTS, false)).toBe(false);
+  });
+
+  it('returns false on attempt exceeding ceiling', () => {
+    expect(shouldRetry(4, MAX_ATTEMPTS, false)).toBe(false);
   });
 });
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -5,6 +5,8 @@ import {
   getAllAgentNames,
   buildAssetMaps,
   buildFullSkillsMap,
+  partitionSelectablePlugins,
+  WORKFLOW_ORDER,
   SHADOW_RENAMES,
   LEGACY_SKILL_NAMES,
   LEGACY_AGENT_NAMES,
@@ -303,5 +305,115 @@ describe('LEGACY_AGENT_NAMES consistency', () => {
         `LEGACY_AGENT_NAMES entry '${legacyName}' must not appear in getAllAgentNames() — remove it from LEGACY_AGENT_NAMES or update the plugin registry`,
       ).not.toContain(legacyName);
     }
+  });
+});
+
+describe('partitionSelectablePlugins', () => {
+  const EXCLUDED = new Set(['devflow-core-skills', 'devflow-ambient', 'devflow-audit-claude']);
+
+  it('command-bearing plugins land in workflow bucket', () => {
+    const { workflow } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const workflowNames = workflow.map(pl => pl.name);
+    // Spot-check known workflow plugins
+    expect(workflowNames).toContain('devflow-plan');
+    expect(workflowNames).toContain('devflow-bug-analysis');
+    expect(workflowNames).toContain('devflow-implement');
+    expect(workflowNames).toContain('devflow-code-review');
+    // All workflow plugins must have at least one command
+    for (const pl of workflow) {
+      expect(pl.commands.length, `${pl.name} in workflow bucket must have commands`).toBeGreaterThan(0);
+    }
+  });
+
+  it('command-less plugins land in language bucket', () => {
+    const { language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const languageNames = language.map(pl => pl.name);
+    // Spot-check known language plugins
+    expect(languageNames).toContain('devflow-typescript');
+    expect(languageNames).toContain('devflow-react');
+    expect(languageNames).toContain('devflow-go');
+    expect(languageNames).toContain('devflow-python');
+    // All language plugins must have zero commands
+    for (const pl of language) {
+      expect(pl.commands.length, `${pl.name} in language bucket must have no commands`).toBe(0);
+    }
+  });
+
+  it('excluded plugins appear in neither bucket', () => {
+    const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const allNames = new Set([...workflow, ...language].map(pl => pl.name));
+    for (const excluded of EXCLUDED) {
+      expect(allNames.has(excluded), `${excluded} must not appear in any bucket`).toBe(false);
+    }
+  });
+
+  it('workflow + language covers all selectable (non-excluded) plugins', () => {
+    const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const selectableCount = DEVFLOW_PLUGINS.filter(pl => !EXCLUDED.has(pl.name)).length;
+    expect(workflow.length + language.length).toBe(selectableCount);
+  });
+
+  it('buckets are disjoint', () => {
+    const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const workflowNames = new Set(workflow.map(pl => pl.name));
+    for (const pl of language) {
+      expect(workflowNames.has(pl.name), `${pl.name} must not appear in both buckets`).toBe(false);
+    }
+  });
+
+  it('does not mutate the input array', () => {
+    const inputCopy = [...DEVFLOW_PLUGINS];
+    partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    expect(DEVFLOW_PLUGINS).toEqual(inputCopy);
+  });
+
+  it('preserves DEVFLOW_PLUGINS ordering within each bucket', () => {
+    const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    // Collect the order of workflow and language plugins from the original registry
+    const registryWorkflowOrder = DEVFLOW_PLUGINS
+      .filter(pl => !EXCLUDED.has(pl.name) && pl.commands.length > 0)
+      .map(pl => pl.name);
+    const registryLanguageOrder = DEVFLOW_PLUGINS
+      .filter(pl => !EXCLUDED.has(pl.name) && pl.commands.length === 0)
+      .map(pl => pl.name);
+    expect(workflow.map(pl => pl.name)).toEqual(registryWorkflowOrder);
+    expect(language.map(pl => pl.name)).toEqual(registryLanguageOrder);
+  });
+
+  it('returns empty buckets for empty input', () => {
+    const { workflow, language } = partitionSelectablePlugins([]);
+    expect(workflow).toHaveLength(0);
+    expect(language).toHaveLength(0);
+  });
+});
+
+describe('WORKFLOW_ORDER', () => {
+  it('is exported and contains /bug-analysis', () => {
+    expect(WORKFLOW_ORDER).toContain('/bug-analysis');
+  });
+
+  it('/bug-analysis appears after /self-review', () => {
+    const selfReviewIdx = WORKFLOW_ORDER.indexOf('/self-review');
+    const bugAnalysisIdx = WORKFLOW_ORDER.indexOf('/bug-analysis');
+    expect(selfReviewIdx).toBeGreaterThanOrEqual(0);
+    expect(bugAnalysisIdx).toBeGreaterThan(selfReviewIdx);
+  });
+
+  it('every workflow plugin command appears in WORKFLOW_ORDER (regression guard)', () => {
+    const { workflow } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const workflowOrderSet = new Set(WORKFLOW_ORDER);
+    for (const pl of workflow) {
+      for (const cmd of pl.commands) {
+        // Commands in plugin definitions use the /name format, matching WORKFLOW_ORDER entries
+        expect(
+          workflowOrderSet.has(cmd),
+          `Command '${cmd}' from plugin '${pl.name}' must appear in WORKFLOW_ORDER`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('has no duplicate entries', () => {
+    expect(new Set(WORKFLOW_ORDER).size).toBe(WORKFLOW_ORDER.length);
   });
 });

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -411,6 +411,18 @@ describe('WORKFLOW_ORDER', () => {
     }
   });
 
+  it('every WORKFLOW_ORDER entry corresponds to a real command in the registry (reverse regression guard)', () => {
+    // Build the full set of all commands across ALL plugins (including excluded ones like
+    // devflow-audit-claude, which owns /audit-claude and is intentionally in WORKFLOW_ORDER).
+    const allCommands = new Set(DEVFLOW_PLUGINS.flatMap(pl => pl.commands));
+    for (const cmd of WORKFLOW_ORDER) {
+      expect(
+        allCommands.has(cmd),
+        `WORKFLOW_ORDER entry '${cmd}' must correspond to a real command in DEVFLOW_PLUGINS`,
+      ).toBe(true);
+    }
+  });
+
   it('has no duplicate entries', () => {
     expect(new Set(WORKFLOW_ORDER).size).toBe(WORKFLOW_ORDER.length);
   });

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -192,12 +192,10 @@ describe('optional plugin flag', () => {
   });
 
   it('audit-claude is excluded from init multiselect choices', () => {
-    // Mirrors the filter logic in init.ts — audit-claude should not appear in interactive selector
-    const multiselectPlugins = DEVFLOW_PLUGINS.filter(
-      pl => pl.name !== 'devflow-core-skills' && pl.name !== 'devflow-ambient' && pl.name !== 'devflow-audit-claude',
-    );
-    const names = multiselectPlugins.map(pl => pl.name);
-    expect(names).not.toContain('devflow-audit-claude');
+    // partitionSelectablePlugins excludes devflow-audit-claude from both buckets
+    const { workflow, language } = partitionSelectablePlugins(DEVFLOW_PLUGINS);
+    const selectableNames = [...workflow, ...language].map(pl => pl.name);
+    expect(selectableNames).not.toContain('devflow-audit-claude');
     // But it still exists in the registry (installable via --plugin=audit-claude)
     expect(DEVFLOW_PLUGINS.find(p => p.name === 'devflow-audit-claude')).toBeDefined();
   });


### PR DESCRIPTION
## Problem Being Solved
Three init-flow rough edges: an unwanted user/local scope prompt, a missing `/bug-analysis` entry in the post-install command list, and a single plugin list that conflated workflow and language plugins.

## Key Changes to Highlight
- Interactive init always installs on user scope (scope prompt removed; `--scope` flag kept).
- `/bug-analysis` now appears in the "Available commands" note, guarded by a coverage test.
- Plugin selection split into two steps: workflow plugins, then language plugins.
- New pure helper `partitionSelectablePlugins` + exported `WORKFLOW_ORDER`, both unit-tested.

## Breaking Changes
None for scripted use (`--plugin`, `--scope` unchanged). Interactive scope choice is removed by design; deep local-scope removal is deferred.

## Reviewer Focus Areas
- The bounded re-prompt loop and combined non-empty validation (language-only path).
- `isCancel` handling on both new multiselects.
- Correct exclusions in `partitionSelectablePlugins`.