### PR TITLE
fix(reliability): bound acquireMkdirLock loop when stale lock is un-removable

### DIFF
--- a/src/cli/utils/mkdir-lock.ts
+++ b/src/cli/utils/mkdir-lock.ts
@@ -32,8 +32,13 @@ export async function acquireMkdirLock(lockDir: string, timeoutMs = 30_000, stal
       try {
         const stat = await fs.stat(lockDir);
         if (Date.now() - stat.mtimeMs > staleMs) {
-          try { await fs.rmdir(lockDir); } catch { /* race condition OK */ }
-          continue;
+          // D57: Track whether rmdir succeeded. Only retry immediately on success.
+          // If the lock dir is un-removable (e.g. ENOTEMPTY, permission error) we must
+          // fall through to the timeout guard + backoff below — never spin unconditionally.
+          let removed = true;
+          try { await fs.rmdir(lockDir); } catch { removed = false; /* race condition OK */ }
+          if (removed) continue; // stale lock cleared → retry mkdir immediately
+          // else: un-removable stale lock → fall through to timeout guard + backoff
         }
       } catch { /* lock vanished between EEXIST and stat */ }
       if (Date.now() - start >= timeoutMs) return false;

--- a/tests/mkdir-lock.test.ts
+++ b/tests/mkdir-lock.test.ts
@@ -54,4 +54,26 @@ describe('acquireMkdirLock', () => {
     const acquired = await acquireMkdirLock(lockDir, 1_000, 0);
     expect(acquired).toBe(true);
   });
+
+  it('returns false within timeoutMs when stale lock is un-removable (non-empty dir)', async () => {
+    // Regression test: if rmdir fails (e.g. ENOTEMPTY), the loop must not spin indefinitely.
+    // Before the fix, `continue` on rmdir failure skipped the timeout guard → infinite spin.
+    const lockDir = path.join(tmpDir, '.test.lock');
+    fs.mkdirSync(lockDir);
+    // Place a file inside so fs.rmdir() fails with ENOTEMPTY — a portable way to make it
+    // un-removable without permission hacks.
+    fs.writeFileSync(path.join(lockDir, 'sentinel'), '');
+
+    const timeoutMs = 300;
+    const before = Date.now();
+    // staleMs=1 makes the just-created dir immediately "stale"; timeoutMs=300 bounds the wait.
+    const acquired = await acquireMkdirLock(lockDir, timeoutMs, 1);
+    const elapsed = Date.now() - before;
+
+    expect(acquired).toBe(false);
+    // Must not return instantly (proves it waited for the timeout, not a fast-path bail-out)
+    expect(elapsed).toBeGreaterThanOrEqual(timeoutMs - 20);
+    // Must complete well within a generous ceiling (not hanging due to the unbounded spin)
+    expect(elapsed).toBeLessThan(1_500);
+  }, 3_000); // test-level safety net: fail the test at 3s rather than letting the suite hang
 });


### PR DESCRIPTION
## Summary
`acquireMkdirLock` (`src/cli/utils/mkdir-lock.ts`) could spin at 100% CPU indefinitely, escaping its own `timeoutMs`. The stale-break path did `rmdir` then a bare `continue`, which jumped back to the top of the `while (true)` loop and skipped BOTH the timeout guard and the 100ms backoff. If a lock dir was simultaneously **stale** (old mtime) and **un-removable** (`rmdir` fails — e.g. a non-empty dir → `ENOTEMPTY`, or a permissions error), the loop never terminated. This violated the "every loop/retry has a fixed upper bound" reliability rule.

## Fix
Track whether `rmdir` succeeded. Only `continue` (retry immediately) on a successful stale-break; on failure, fall through to the existing timeout guard + 100ms backoff so the loop stays bounded and returns `false` after `timeoutMs` (the correct fail-closed outcome — callers like `assign-anchor` then don't proceed). No change to the signature, the happy path, or the normal-contention path.

## Test
Added a regression test that makes the lock dir un-removable by placing a file inside it (`rmdir` → `ENOTEMPTY`) with `staleMs=1`. Against the old code the test **times out at 3000ms** (proving the spin); with the fix it returns `false` at ~305ms. Full suite: 1924 tests pass, 0 TypeScript warnings; shared-primitive consumers (queue-append, memory refresh, decisions ledger-ops) all green — no regressions.

## Context
The lock mechanism itself is warranted and unchanged — it serializes concurrent `assign-anchor` numbering and multi-file ledger rendering across processes and languages (.cjs helpers + .ts CLI). This fixes only the unbounded-loop edge case. Split out of the PR #256 code review (surfaced there as ISSUE-23, deferred from that PR to keep it focused).