### PR TITLE
feat(hooks): capture full turn content — remove per-entry truncation

### DIFF
--- a/scripts/hooks/capture-prompt
+++ b/scripts/hooks/capture-prompt
@@ -51,11 +51,6 @@ if [ -z "$PROMPT" ]; then
   exit 0
 fi
 
-# Truncate to 2000 chars (AC-F1)
-if [ ${#PROMPT} -gt 2000 ]; then
-  PROMPT="${PROMPT:0:2000}... [truncated]"
-fi
-
 source "$SCRIPT_DIR/queue-append" || { echo "capture-prompt: failed to source queue-append" >&2; exit 1; }
 
 # --- AC-P1: exactly ONE config-read fork, fetching both memory + decisions fields ---

--- a/scripts/hooks/capture-question
+++ b/scripts/hooks/capture-question
@@ -136,11 +136,6 @@ _QUESTION_COUNT=0
 while IFS=$'\t' read -r Q A; do
   [ -z "$Q" ] && continue
 
-  # Q and A truncated INDEPENDENTLY at 1000 chars each so a long question can't
-  # swallow the answer.
-  if [ ${#Q} -gt 1000 ]; then Q="${Q:0:1000}... [truncated]"; fi
-  if [ ${#A} -gt 1000 ]; then A="${A:0:1000}... [truncated]"; fi
-
   CONTENT="Q: ${Q}
 A: ${A}"
   TS=$(date +%s)

--- a/scripts/hooks/capture-turn
+++ b/scripts/hooks/capture-turn
@@ -58,11 +58,6 @@ if [ -z "$ASSISTANT_MSG" ]; then
   exit 0
 fi
 
-# Truncate to 2000 chars
-if [ ${#ASSISTANT_MSG} -gt 2000 ]; then
-  ASSISTANT_MSG="${ASSISTANT_MSG:0:2000}... [truncated]"
-fi
-
 source "$SCRIPT_DIR/queue-append" || { echo "capture-turn: failed to source queue-append" >&2; exit 1; }
 
 # --- AC-P1: exactly ONE config-read fork, fetching both memory + decisions fields ---

--- a/tests/capture-hooks.test.ts
+++ b/tests/capture-hooks.test.ts
@@ -118,11 +118,11 @@ describe('capture-prompt', () => {
     expect(dream).toEqual([{ role: 'user', content: 'hello world', ts: expect.any(Number) }]);
   });
 
-  it('AC-F1: content truncated at 2000 chars', () => {
+  it('AC-F1: long prompt passes through whole (no truncation)', () => {
     const longPrompt = 'x'.repeat(2500);
     runHook(CAPTURE_PROMPT, { cwd: projectDir, prompt: longPrompt }, homeDir);
     const mem = readJsonl(path.join(projectDir, '.devflow', 'memory', '.pending-turns.jsonl'));
-    expect((mem[0].content as string).length).toBe(2000 + '... [truncated]'.length);
+    expect((mem[0].content as string)).toBe(longPrompt);
   });
 
   it('empty prompt -> zero appends, no .devflow scaffolding', () => {
@@ -251,11 +251,11 @@ describe('capture-turn', () => {
     expect(fs.existsSync(path.join(projectDir, '.devflow'))).toBe(false);
   });
 
-  it('content truncated at 2000 chars', () => {
+  it('long message passes through whole (no truncation)', () => {
     const longMessage = 'b'.repeat(5000);
     runHook(CAPTURE_TURN, { cwd: projectDir, session_id: 't', last_assistant_message: longMessage }, homeDir);
     const mem = readJsonl(path.join(projectDir, '.devflow', 'memory', '.pending-turns.jsonl'));
-    expect((mem[0].content as string).length).toBe(2000 + '... [truncated]'.length);
+    expect((mem[0].content as string)).toBe(longMessage);
   });
 
   it('ignores legacy response_text field — only last_assistant_message gates capture', () => {
@@ -390,7 +390,7 @@ describe('capture-question', () => {
     expect(mem[0].content).toBe('Q: Pick colors\nA: Red; Blue');
   });
 
-  it('truncation: Q and A are capped at 1000 chars INDEPENDENTLY', () => {
+  it('long Q and A pass through whole (no truncation)', () => {
     const longQ = 'Q'.repeat(1500);
     const longA = 'A'.repeat(1500);
     runHook(
@@ -406,8 +406,8 @@ describe('capture-question', () => {
     const mem = readJsonl(path.join(projectDir, '.devflow', 'memory', '.pending-turns.jsonl'));
     const content = mem[0].content as string;
     const [qPart, aPart] = content.split('\nA: ');
-    expect(qPart.replace('Q: ', '')).toHaveLength(1000 + '... [truncated]'.length);
-    expect(aPart).toHaveLength(1000 + '... [truncated]'.length);
+    expect(qPart.replace('Q: ', '')).toBe(longQ);
+    expect(aPart).toBe(longA);
   });
 
   it('hostile answer content is safely escaped (quotes, $(...), newlines collapsed)', () => {


### PR DESCRIPTION
## Summary

- Removes the 2000-char per-entry cap from `capture-prompt` (PROMPT) and `capture-turn` (ASSISTANT_MSG)
- Removes the independent 1000-char caps on Q and A from `capture-question`
- Updates three tests to assert full pass-through of long content instead of capped length

## Why

User decision: captured turns must be stored whole. Truncating at capture time degrades the fidelity of both the memory worker input and the Dream agent's decision-detection corpus. A single very-long turn now reaches the haiku memory worker and Dream agent in full — that is the intended behaviour.

## What stays unchanged

The queue line-count overflow cap in `queue-append` (200→100 lines) is **not touched**. It bounds total queue size (entry count), not per-entry content, and continues to protect against unbounded queue growth across many turns.

## Residual risk

A single very large turn (e.g. a multi-thousand-line assistant response) is now stored whole in the JSONL queue and later consumed by the haiku memory worker and Dream agent. Both consumers receive the full text in their prompt context. This is accepted: full fidelity was explicitly preferred over the previous lossy cap.

## Changes

- `scripts/hooks/capture-prompt` — removed 4-line `if [ ${#PROMPT} -gt 2000 ]` block and `# Truncate to 2000 chars (AC-F1)` comment
- `scripts/hooks/capture-turn` — removed 3-line `if [ ${#ASSISTANT_MSG} -gt 2000 ]` block
- `scripts/hooks/capture-question` — removed 4-line Q/A truncation block (comment + two `if` guards)
- `tests/capture-hooks.test.ts` — rewrote 3 tests (`AC-F1: content truncated`, `content truncated at 2000 chars`, `truncation: Q and A capped independently`) to assert identity pass-through of long inputs

## Test results

All 1968 tests pass (`vitest run`). Build passes (`npm run build`).