### PR TITLE
refactor(install): registry-diff asset sweep + uninstall lifecycle parity

### DIFF
--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -6,7 +6,8 @@ import * as p from '@clack/prompts';
 import color from 'picocolors';
 import { getInstallationPaths, getClaudeDirectory, getManagedSettingsPath } from '../../targets/claude-code/claude-paths.js';
 import { getGitRoot } from '../../core/git.js';
-import { DEVFLOW_PLUGINS, getAllSkillNames, parsePluginSelection, prefixSkillName, type PluginDefinition } from '../../core/plugins.js';
+import { DEVFLOW_PLUGINS, getAllSkillNames, getAllAgentNames, getAllCommandNames, parsePluginSelection, prefixSkillName, type PluginDefinition } from '../../core/plugins.js';
+import { sweepOrphanedAssets } from '../../core/orphan-sweep.js';
 import { LEGACY_SKILL_NAMES } from '../../targets/claude-code/legacy.js';
 import { removeAmbientHook } from './ambient.js';
 import { removeMemoryHooks } from './memory.js';
@@ -148,6 +149,9 @@ export function resolveSecurityRemovalDecision(opts: {
  * @D6 avoids PF-014: the caller must NOT process.exit() after a cancel/decline response;
  * removeAllDevFlow has already run by the time the prompt fires, so removeDevFlowInstallArtifacts
  * must execute on every non-confirm path to leave a clean end-state (applies ADR-003).
+ * @D7 keepDocs gate: when the caller passes --keep-docs, the entire ~/.devflow dir cleanup
+ * prompt is suppressed — artifacts-only regardless of isTTY or userContent. This prevents
+ * --keep-docs from triggering prompts about skill shadows or preference-profile.md.
  */
 export function resolveDevflowDirCleanup(opts: {
   scope: 'user' | 'local';
@@ -155,9 +159,13 @@ export function resolveDevflowDirCleanup(opts: {
   userContent: string[];
   devflowDir: string;
   homeDir: string;
+  keepDocs?: boolean;
 }): 'artifacts-only' | 'prompt' {
   // Local scope never removes project data — only install artifacts.
   if (opts.scope !== 'user') return 'artifacts-only';
+
+  // --keep-docs: suppress the full cleanup prompt entirely; artifacts-only.
+  if (opts.keepDocs) return 'artifacts-only';
 
   // Precondition guard: devflowDir must be a well-known, safe-to-rm path.
   // Any anomalous value (DEVFLOW_DIR override, bare homedir, filesystem root)
@@ -234,6 +242,12 @@ export async function enumerateUserDevFlowContent(devflowDir: string): Promise<s
     items.push('agent-models.json (agent model assignments)');
   } catch { /* absent */ }
 
+  // hud.json — user HUD enable/disable preference and display config
+  try {
+    await fs.access(path.join(devflowDir, 'hud.json'));
+    items.push('hud.json (HUD configuration)');
+  } catch { /* absent */ }
+
   return items;
 }
 
@@ -273,18 +287,35 @@ export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose:
     }
   } catch { /* proxy.pid absent or unreadable — non-fatal */ }
 
-  const proxyArtifacts: Array<{ relPath: string; isDir?: boolean }> = [
+  // All install artifacts removed non-fatally (avoids PF-009).
+  // isDir MUST be marked true for directories — fs.rm throws a TypeError for
+  // directories without recursive:true, which the per-item catch swallows
+  // silently, leaving the directory on disk (avoids the isDir===true gotcha).
+  const installArtifacts: Array<{ relPath: string; isDir?: boolean }> = [
+    // per-agent model overrides — removed so reinstall starts with shipped defaults
+    { relPath: 'agent-models.json' },
+    // migration run-state — removed so migrations re-run cleanly on reinstall
+    { relPath: 'migrations.json' },
+    // HUD configuration (enabled/disabled preference)
+    { relPath: 'hud.json' },
+    // cost history — auto-generated; not user-authored
+    { relPath: path.join('costs', 'sessions'), isDir: true },
+    { relPath: path.join('costs', 'archive.jsonl') },
+    // proxy artifacts
     { relPath: 'proxy.json' },
     { relPath: 'proxy-routing.json' },
     { relPath: 'proxy.pid' },
     { relPath: '.proxy-spawn.lock', isDir: true },
-    { relPath: path.join('logs', 'proxy.log') },
-    // Model-discovery cache — populated by discoverExternalModels during enable / agents TUI.
-    // isDir:true so rm recurses into external-models-v1-*.json cache entries.
-    // relPath derived from modelCacheDir to stay byte-locked to write sites (avoids PF-013).
-    { relPath: path.relative(devflowDir, modelCacheDir(devflowDir)), isDir: true },
+    // per-project hook logs (logs/{project-slug}/) AND global logs — remove the
+    // whole logs/ tree; covers proxy.log, debug logs, and any project-slug dirs.
+    { relPath: 'logs', isDir: true },
+    // Model-discovery cache — the cache/ parent is removed (not just cache/models)
+    // so any future sub-directories are also cleaned up.
+    // relPath derived from modelCacheDir's parent to stay byte-locked to write
+    // sites (avoids PF-013); removing the parent also removes cache/models.
+    { relPath: path.relative(devflowDir, path.dirname(modelCacheDir(devflowDir))), isDir: true },
   ];
-  for (const artifact of proxyArtifacts) {
+  for (const artifact of installArtifacts) {
     const fullPath = path.join(devflowDir, artifact.relPath);
     try {
       await fs.rm(fullPath, { force: true, recursive: artifact.isDir === true });
@@ -294,15 +325,33 @@ export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose:
 }
 
 /**
- * Check if Devflow is installed at the given paths
+ * Check if Devflow is installed at the given claudeDir by detecting any
+ * owned namespace: commands/devflow/, agents/devflow/, or any skill dir
+ * whose name starts with the devflow: namespace prefix.
+ *
+ * Keying off commands/devflow/ alone misses installs where the user selected
+ * a commandless plugin set — agents and skills may still be present.
  */
-async function isDevFlowInstalled(claudeDir: string): Promise<boolean> {
+export async function isDevFlowInstalled(claudeDir: string): Promise<boolean> {
+  // Check commands namespace
   try {
     await fs.access(path.join(claudeDir, 'commands', 'devflow'));
     return true;
-  } catch {
-    return false;
-  }
+  } catch { /* not present */ }
+
+  // Check agents namespace
+  try {
+    await fs.access(path.join(claudeDir, 'agents', 'devflow'));
+    return true;
+  } catch { /* not present */ }
+
+  // Check for any installed skill under the devflow: namespace
+  try {
+    const entries = await fs.readdir(path.join(claudeDir, 'skills'));
+    if (entries.some(e => e.startsWith('devflow:'))) return true;
+  } catch { /* skills dir absent or unreadable */ }
+
+  return false;
 }
 
 export const uninstallCommand = new Command('uninstall')
@@ -391,21 +440,54 @@ export const uninstallCommand = new Command('uninstall')
     if (dryRun) {
       p.log.info(`Scope(s): ${scopesToUninstall.join(', ')} (dry-run shows all detected scopes)`);
 
-      const assets = isSelectiveUninstall
-        ? computeAssetsToRemove(selectedPlugins, DEVFLOW_PLUGINS)
-        : computeAssetsToRemove(DEVFLOW_PLUGINS, DEVFLOW_PLUGINS);
-
-      // Detect extras that would be cleaned up (full uninstall only)
-      const extras: string[] = [];
-      if (!isSelectiveUninstall) {
+      if (isSelectiveUninstall) {
+        // Selective: compute from registry — this accurately reflects what would be removed.
+        const assets = computeAssetsToRemove(selectedPlugins, DEVFLOW_PLUGINS);
+        const plan = formatDryRunPlan(assets);
+        for (const line of plan.split('\n')) {
+          p.log.info(line);
+        }
+      } else {
+        // Full uninstall: the real path does rm -rf on entire directories plus a
+        // skills sweep. Enumerate what is actually on disk for each detected scope
+        // rather than computing from the registry (which misses legacy/orphaned assets).
+        const extras: string[] = [];
+        for (const scope of scopesToUninstall) {
+          try {
+            const paths = await getInstallationPaths(scope);
+            const { claudeDir: cd, devflowDir: dd } = paths;
+            // Whole directories removed by removeAllDevFlow
+            for (const dir of [
+              path.join(cd, 'commands', 'devflow'),
+              path.join(cd, 'agents', 'devflow'),
+              path.join(cd, 'rules', 'devflow'),
+              path.join(dd, 'scripts'),
+            ]) {
+              try { await fs.access(dir); extras.push(dir); } catch { /* absent */ }
+            }
+            // Skills: list every devflow:* directory actually on disk
+            try {
+              const skillEntries = await fs.readdir(path.join(cd, 'skills'));
+              for (const e of skillEntries) {
+                if (e.startsWith('devflow:')) extras.push(path.join(cd, 'skills', e));
+              }
+            } catch { /* skills dir absent */ }
+            // ~/.devflow install artifacts
+            extras.push(`${dd} install artifacts (manifest.json, agent-models.json, migrations.json, hud.json, logs/, costs/, cache/, proxy artifacts)`);
+          } catch { /* scope path resolution failed */ }
+        }
+        // Project .devflow/ data dir
         const devflowDataDir = path.join(process.cwd(), '.devflow');
-        try { await fs.access(devflowDataDir); extras.push('.devflow/'); } catch { /* noop */ }
-        extras.push('hooks in settings.json', 'scripts in ~/.devflow/');
-      }
+        try { await fs.access(devflowDataDir); extras.push(`${devflowDataDir} (if confirmed)`); } catch { /* noop */ }
+        extras.push('hooks removed from settings.json');
 
-      const plan = formatDryRunPlan(assets, extras.length > 0 ? extras : undefined);
-      for (const line of plan.split('\n')) {
-        p.log.info(line);
+        if (extras.length === 0) {
+          p.log.info('Nothing to remove.');
+        } else {
+          for (const line of extras) {
+            p.log.info(`  ${line}`);
+          }
+        }
       }
 
       p.outro(color.dim('No changes made (dry run)'));
@@ -435,6 +517,21 @@ export const uninstallCommand = new Command('uninstall')
       }
 
       if (isSelectiveUninstall) {
+        // Revert GPT agent frontmatter BEFORE removing agent files — strips GPT model
+        // lines from installed agent frontmatter while the files are still present.
+        // Non-fatal: tolerate missing agents dir or revert errors.
+        {
+          const agentsInstallDir = path.join(claudeDir, 'agents', 'devflow');
+          try {
+            await fs.access(agentsInstallDir);
+            await revertExternalAgents({
+              installDir: agentsInstallDir,
+              devflowDir,
+              onWarning: (msg) => { if (verbose) p.log.warn(msg); },
+            });
+          } catch { /* agents dir absent or revert failed — non-fatal */ }
+        }
+
         await removeSelectedPlugins(claudeDir, selectedPlugins, verbose);
 
         // Clean up ambient hook if ambient plugin is being removed
@@ -488,6 +585,7 @@ export const uninstallCommand = new Command('uninstall')
             userContent,
             devflowDir,
             homeDir: os.homedir(),
+            keepDocs: !!options.keepDocs,
           });
 
           if (cleanupDecision === 'artifacts-only') {
@@ -768,7 +866,7 @@ export const uninstallCommand = new Command('uninstall')
 /**
  * Remove all Devflow assets (full uninstall).
  */
-async function removeAllDevFlow(
+export async function removeAllDevFlow(
   claudeDir: string,
   devflowScriptsDir: string,
   verbose: boolean,
@@ -827,10 +925,12 @@ async function removeAllDevFlow(
 
 /**
  * Remove only specific plugin assets (selective uninstall).
- * For commands and agents: remove files belonging to selected plugins.
+ * For commands and agents: remove files belonging to selected plugins, then
+ * sweep the install directory for any orphaned assets whose names left the
+ * registry (retired agents/commands survive indefinitely without the sweep).
  * For skills: only remove skills that are NOT used by any remaining plugin.
  */
-async function removeSelectedPlugins(
+export async function removeSelectedPlugins(
   claudeDir: string,
   plugins: typeof DEVFLOW_PLUGINS,
   verbose: boolean,
@@ -889,4 +989,22 @@ async function removeSelectedPlugins(
       }
     } catch { /* Rule file might not exist */ }
   }
+
+  // Registry-diff sweep: remove any agents or commands that were retired from
+  // the registry (their names no longer appear in getAllAgentNames / getAllCommandNames).
+  // Without this sweep, a plugin removal followed by a renamed or deleted agent
+  // leaves the old .md file on disk permanently.
+  //
+  // knownNames spans ALL plugins so assets belonging to OTHER (non-selected) plugins
+  // are never swept — only truly orphaned names are removed (avoids PF-012).
+  await sweepOrphanedAssets(
+    agentsDir,
+    new Set(getAllAgentNames()),
+    (entry) => entry.endsWith('.md') ? entry.slice(0, -'.md'.length) : null,
+  );
+  await sweepOrphanedAssets(
+    commandsDir,
+    new Set(getAllCommandNames()),
+    (entry) => entry.endsWith('.md') ? entry.slice(0, -'.md'.length) : null,
+  );
 }

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -6,7 +6,7 @@ import * as p from '@clack/prompts';
 import color from 'picocolors';
 import { getInstallationPaths, getClaudeDirectory, getManagedSettingsPath } from '../../targets/claude-code/claude-paths.js';
 import { getGitRoot } from '../../core/git.js';
-import { DEVFLOW_PLUGINS, getAllSkillNames, getAllAgentNames, getAllCommandNames, parsePluginSelection, prefixSkillName, type PluginDefinition } from '../../core/plugins.js';
+import { DEVFLOW_PLUGINS, SKILL_NAMESPACE, getAllSkillNames, getAllAgentNames, getAllCommandNames, parsePluginSelection, prefixSkillName, type PluginDefinition } from '../../core/plugins.js';
 import { sweepOrphanedAssets } from '../../core/orphan-sweep.js';
 import { LEGACY_SKILL_NAMES } from '../../targets/claude-code/legacy.js';
 import { removeAmbientHook } from './ambient.js';
@@ -17,7 +17,7 @@ import { removeHudStatusLine } from './hud.js';
 import { removeContextHook } from './context.js';
 import { applyDisableToSettings } from './proxy.js';
 import { readProxyState, DEFAULT_PROXY_PORT } from '../../core/proxy-state.js';
-import { modelCacheDir } from '../../core/cache.js';
+import { hudCacheDir } from '../../core/cache.js';
 import { revertExternalAgents } from '../../core/agent-models.js';
 import type { Settings } from '../../targets/claude-code/hooks.js';
 import { detectShell, getProfilePath } from '../../core/safe-delete.js';
@@ -252,13 +252,19 @@ export async function enumerateUserDevFlowContent(devflowDir: string): Promise<s
 }
 
 /**
- * Remove only Devflow install artifacts from devflowDir: manifest.json.
- * The scripts/ directory is already removed by removeAllDevFlow; this handles
- * the remaining install state so the manifest does not outlive the assets.
+ * Remove Devflow install artifacts from devflowDir: manifest.json, migrations.json,
+ * proxy artifacts, logs/, costs/, and cache/.
+ * The scripts/ directory is already removed by removeAllDevFlow.
  *
  * Used for:
  *   - Local scope (always — never removes project data under .devflow/)
  *   - User scope when full-dir confirm is declined or session is non-interactive
+ *
+ * @D8 Nothing enumerated by enumerateUserDevFlowContent may appear in this list.
+ * This function runs on the decline, cancel, non-interactive AND --keep-docs paths,
+ * so an entry here is deleted even when the user answers "no" to the full wipe.
+ * User-authored state (skill/rule shadows, preference-profile.md, learning.json,
+ * agent-models.json, hud.json) is removed only by the confirmed full-dir rm.
  */
 export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose: boolean): Promise<void> {
   const manifestPath = path.join(devflowDir, 'manifest.json');
@@ -292,15 +298,12 @@ export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose:
   // directories without recursive:true, which the per-item catch swallows
   // silently, leaving the directory on disk (avoids the isDir===true gotcha).
   const installArtifacts: Array<{ relPath: string; isDir?: boolean }> = [
-    // per-agent model overrides — removed so reinstall starts with shipped defaults
-    { relPath: 'agent-models.json' },
     // migration run-state — removed so migrations re-run cleanly on reinstall
     { relPath: 'migrations.json' },
-    // HUD configuration (enabled/disabled preference)
-    { relPath: 'hud.json' },
-    // cost history — auto-generated; not user-authored
-    { relPath: path.join('costs', 'sessions'), isDir: true },
-    { relPath: path.join('costs', 'archive.jsonl') },
+    // cost history — auto-generated session telemetry, not user-authored.
+    // The whole costs/ tree is removed so sessions/ and archive.jsonl cannot
+    // drift from their write sites in src/hud/cost-history.ts (avoids PF-013).
+    { relPath: 'costs', isDir: true },
     // proxy artifacts
     { relPath: 'proxy.json' },
     { relPath: 'proxy-routing.json' },
@@ -309,14 +312,22 @@ export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose:
     // per-project hook logs (logs/{project-slug}/) AND global logs — remove the
     // whole logs/ tree; covers proxy.log, debug logs, and any project-slug dirs.
     { relPath: 'logs', isDir: true },
-    // Model-discovery cache — the cache/ parent is removed (not just cache/models)
-    // so any future sub-directories are also cleaned up.
-    // relPath derived from modelCacheDir's parent to stay byte-locked to write
-    // sites (avoids PF-013); removing the parent also removes cache/models.
-    { relPath: path.relative(devflowDir, path.dirname(modelCacheDir(devflowDir))), isDir: true },
+    // Model-discovery + HUD component caches. hudCacheDir() is the authoritative
+    // accessor for the cache/ parent (modelCacheDir() resolves beneath it), so the
+    // removal site stays byte-locked to the write sites (avoids PF-013).
+    { relPath: path.relative(devflowDir, hudCacheDir(devflowDir)), isDir: true },
   ];
   for (const artifact of installArtifacts) {
     const fullPath = path.join(devflowDir, artifact.relPath);
+    // Containment invariant: every artifact must resolve to a path STRICTLY inside
+    // devflowDir. A derived relPath that ever collapsed to '' or '..' would turn the
+    // recursive rm below into a wipe of devflowDir itself (or an ancestor). Asserting
+    // it in production code — not only in tests — keeps the invariant load-bearing
+    // (reliability rule) and never throws (engineering rule).
+    const containment = path.relative(devflowDir, fullPath);
+    if (containment === '' || containment.startsWith('..') || path.isAbsolute(containment)) {
+      continue;
+    }
     try {
       await fs.rm(fullPath, { force: true, recursive: artifact.isDir === true });
       if (verbose) p.log.success(`Removed ${artifact.relPath}`);
@@ -348,7 +359,7 @@ export async function isDevFlowInstalled(claudeDir: string): Promise<boolean> {
   // Check for any installed skill under the devflow: namespace
   try {
     const entries = await fs.readdir(path.join(claudeDir, 'skills'));
-    if (entries.some(e => e.startsWith('devflow:'))) return true;
+    if (entries.some(e => e.startsWith(SKILL_NAMESPACE))) return true;
   } catch { /* skills dir absent or unreadable */ }
 
   return false;
@@ -469,11 +480,11 @@ export const uninstallCommand = new Command('uninstall')
             try {
               const skillEntries = await fs.readdir(path.join(cd, 'skills'));
               for (const e of skillEntries) {
-                if (e.startsWith('devflow:')) extras.push(path.join(cd, 'skills', e));
+                if (e.startsWith(SKILL_NAMESPACE)) extras.push(path.join(cd, 'skills', e));
               }
             } catch { /* skills dir absent */ }
             // ~/.devflow install artifacts
-            extras.push(`${dd} install artifacts (manifest.json, agent-models.json, migrations.json, hud.json, logs/, costs/, cache/, proxy artifacts)`);
+            extras.push(`${dd} install artifacts (manifest.json, migrations.json, logs/, costs/, cache/, proxy artifacts)`);
           } catch { /* scope path resolution failed */ }
         }
         // Project .devflow/ data dir
@@ -481,12 +492,8 @@ export const uninstallCommand = new Command('uninstall')
         try { await fs.access(devflowDataDir); extras.push(`${devflowDataDir} (if confirmed)`); } catch { /* noop */ }
         extras.push('hooks removed from settings.json');
 
-        if (extras.length === 0) {
-          p.log.info('Nothing to remove.');
-        } else {
-          for (const line of extras) {
-            p.log.info(`  ${line}`);
-          }
+        for (const line of extras) {
+          p.log.info(`  ${line}`);
         }
       }
 
@@ -571,7 +578,8 @@ export const uninstallCommand = new Command('uninstall')
         if (scope === 'local') {
           // Local scope: devflowDir is gitRoot/.devflow/ which holds project data
           // (memory, learning, features, docs, config.json). Never remove those —
-          // only remove install artifacts: scripts/ (done above) + manifest.json.
+          // only remove install artifacts: scripts/ (done above) + manifest.json and
+          // the other Devflow-generated artifacts (see removeDevFlowInstallArtifacts).
           await removeDevFlowInstallArtifacts(devflowDir, verbose);
           p.log.info('Local project data (memory, learning, features, docs) preserved');
         } else {
@@ -591,7 +599,7 @@ export const uninstallCommand = new Command('uninstall')
           if (cleanupDecision === 'artifacts-only') {
             await removeDevFlowInstallArtifacts(devflowDir, verbose);
             if (!process.stdin.isTTY && userContent.length > 0) {
-              p.log.info(`${devflowDir} preserved (non-interactive mode — removing scripts and manifest only)`);
+              p.log.info(`${devflowDir} preserved (non-interactive mode — removing scripts and install artifacts only)`);
             }
           } else {
             // cleanupDecision === 'prompt': interactive session with user-authored content present.
@@ -610,13 +618,13 @@ export const uninstallCommand = new Command('uninstall')
               // state. avoids PF-014: process.exit() here would skip removeDevFlowInstallArtifacts,
               // leaving a stale manifest.json that points to assets no longer on disk.
               await removeDevFlowInstallArtifacts(devflowDir, verbose);
-              p.log.info(`${devflowDir} preserved (full removal cancelled; removing scripts and manifest only)`);
+              p.log.info(`${devflowDir} preserved (full removal cancelled; removing scripts and install artifacts only)`);
             } else if (confirmFullCleanup) {
               await fs.rm(devflowDir, { recursive: true, force: true });
               p.log.success(`${devflowDir} removed`);
             } else {
               await removeDevFlowInstallArtifacts(devflowDir, verbose);
-              p.log.info(`${devflowDir} preserved (removing scripts and manifest only)`);
+              p.log.info(`${devflowDir} preserved (removing scripts and install artifacts only)`);
             }
           }
         }

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -192,10 +192,15 @@ export function resolveDevflowDirCleanup(opts: {
  * full cleanup of the directory.
  *
  * Checks for items that exist on disk and are worth backing up:
- *   devflowDir/skills/   — skill shadow overrides (user-maintained)
- *   devflowDir/rules/    — rule shadow overrides (user-maintained)
+ *   devflowDir/skills/              — skill shadow overrides (user-maintained)
+ *   devflowDir/rules/               — rule shadow overrides (user-maintained)
  *   devflowDir/preference-profile.md — dynamic-plan preference profile
  *   devflowDir/learning.json         — global learning agent tuning config
+ *   devflowDir/hud.json              — HUD enable/disable preference and display config
+ *
+ * NOT listed here: agent-models.json — reclassified as an INSTALL ARTIFACT (AC-P1-F4).
+ * Stale per-agent model overrides silently re-apply to renamed/deleted agents on reinstall,
+ * so it must be cleaned up by removeDevFlowInstallArtifacts, not preserved behind a confirm gate.
  *
  * Returns labels for each item that actually exists. Empty array means nothing
  * user-authored is present in the directory.
@@ -236,12 +241,6 @@ export async function enumerateUserDevFlowContent(devflowDir: string): Promise<s
     items.push('learning.json');
   } catch { /* absent */ }
 
-  // agent-models.json — user model/effort assignments for agents
-  try {
-    await fs.access(path.join(devflowDir, 'agent-models.json'));
-    items.push('agent-models.json (agent model assignments)');
-  } catch { /* absent */ }
-
   // hud.json — user HUD enable/disable preference and display config
   try {
     await fs.access(path.join(devflowDir, 'hud.json'));
@@ -264,7 +263,10 @@ export async function enumerateUserDevFlowContent(devflowDir: string): Promise<s
  * This function runs on the decline, cancel, non-interactive AND --keep-docs paths,
  * so an entry here is deleted even when the user answers "no" to the full wipe.
  * User-authored state (skill/rule shadows, preference-profile.md, learning.json,
- * agent-models.json, hud.json) is removed only by the confirmed full-dir rm.
+ * hud.json) is removed only by the confirmed full-dir rm.
+ * agent-models.json is an INSTALL ARTIFACT (stale per-agent overrides silently
+ * re-apply to renamed/deleted agents on reinstall — AC-P1-F4) and therefore
+ * belongs in this list, not in enumerateUserDevFlowContent.
  */
 export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose: boolean): Promise<void> {
   const manifestPath = path.join(devflowDir, 'manifest.json');
@@ -300,6 +302,9 @@ export async function removeDevFlowInstallArtifacts(devflowDir: string, verbose:
   const installArtifacts: Array<{ relPath: string; isDir?: boolean }> = [
     // migration run-state — removed so migrations re-run cleanly on reinstall
     { relPath: 'migrations.json' },
+    // per-agent model overrides — removed so stale keys (keyed to renamed/deleted agents
+    // from the wave-4 agent roster rename) cannot silently re-apply on reinstall (AC-P1-F4)
+    { relPath: 'agent-models.json' },
     // cost history — auto-generated session telemetry, not user-authored.
     // The whole costs/ tree is removed so sessions/ and archive.jsonl cannot
     // drift from their write sites in src/hud/cost-history.ts (avoids PF-013).

--- a/src/core/orphan-sweep.ts
+++ b/src/core/orphan-sweep.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+/**
+ * @file orphan-sweep.ts
+ *
+ * Shared helper for registry-diff sweeps of installed asset directories.
+ * Used by both the install pipeline (installer.ts) and the uninstall pipeline
+ * (uninstall.ts) so the logic lives in exactly one place.
+ */
+
+/**
+ * Remove entries from `dir` that are not present in the `knownNames` registry.
+ *
+ * Only removes entries that `extractRegistryName` accepts (returns non-null for);
+ * entries the predicate skips (returns null) are left completely untouched.
+ *
+ * @param dir - The install directory to sweep.
+ * @param knownNames - Full registry set spanning ALL plugins. Must cover the
+ *   complete installed universe — NOT intersected with any selected-plugin subset.
+ *   Assets from uninstalled plugins must survive a partial sweep.
+ * @param extractRegistryName - Maps a directory entry name to a registry key
+ *   (the name to look up in knownNames), or null to skip this entry entirely.
+ *   For agents and commands: strip the .md extension.
+ *   For skills: strip the devflow: prefix.
+ *
+ * @returns The count of entries matched by the predicate (not the removed count).
+ *   Use for non-vacuousness assertions in tests: a return of 0 means no entry
+ *   matched the predicate and the sweep was a no-op regardless of the registry.
+ *
+ * Per-item failure isolation: both the outer readdir and the inner rm are
+ * independently try/caught — a missing directory is a no-op and a failed
+ * individual removal does not abort the sweep (avoids PF-009).
+ * Never writes, only removes (avoids PF-011).
+ */
+export async function sweepOrphanedAssets(
+  dir: string,
+  knownNames: ReadonlySet<string>,
+  extractRegistryName: (entry: string) => string | null,
+): Promise<number> {
+  let scanned = 0;
+  try {
+    const entries = await fs.readdir(dir);
+    for (const entry of entries) {
+      const registryName = extractRegistryName(entry);
+      if (registryName === null) continue;
+      scanned++;
+      if (!knownNames.has(registryName)) {
+        try {
+          await fs.rm(path.join(dir, entry), { recursive: true, force: true });
+        } catch { /* ignore per-item removal errors (avoids PF-009) */ }
+      }
+    }
+  } catch { /* directory absent or unreadable — not an error (avoids PF-009) */ }
+  return scanned;
+}

--- a/src/targets/claude-code/installer.ts
+++ b/src/targets/claude-code/installer.ts
@@ -5,6 +5,7 @@ import type { PluginDefinition } from '../../core/plugins.js';
 import { DEVFLOW_PLUGINS, SKILL_NAMESPACE, prefixSkillName, unprefixSkillName, getAllSkillNames, getAllAgentNames, getAllCommandNames } from '../../core/plugins.js';
 import { skillsDir, agentsDir, rulesDir, commandsDir, scriptsDir } from '../../core/assets.js';
 import { getPackageRoot } from '../../core/paths.js';
+import { sweepOrphanedAssets } from '../../core/orphan-sweep.js';
 
 // ---------------------------------------------------------------------------
 // Shadow override reporting types
@@ -236,53 +237,6 @@ export async function chmodRecursive(dir: string, mode: number): Promise<void> {
       await fs.chmod(fullPath, mode);
     }
   }
-}
-
-// ---------------------------------------------------------------------------
-// Orphan sweep helper
-// ---------------------------------------------------------------------------
-
-/**
- * Sweep an install directory, removing every entry whose registry name (derived via
- * extractRegistryName) is absent from knownNames.
- *
- * Design constraints:
- * - knownNames MUST span ALL plugins, never just the selected subset — assets from
- *   uninstalled plugins must survive a partial install. If you intersect with the
- *   selected-plugin set here you have introduced a bug.
- * - A missing or unreadable directory is a no-op (avoids PF-009).
- * - Per-item removal failures are swallowed (avoids PF-009 blast-radius).
- * - Only removes entries; never writes (avoids PF-011).
- * - Returns the count of entries matched by the predicate. A count of 0 means the
- *   directory was absent or contained no predicate-matching entries; callers can use
- *   this to detect vacuous sweeps in tests.
- *
- * @param dir - The install directory to sweep.
- * @param knownNames - Full registry set spanning ALL plugins.
- * @param extractRegistryName - Maps a directory entry name to a registry key (the
- *   name to look up in knownNames), or null to skip this entry entirely. For agents
- *   and commands: strip the .md extension. For skills: strip the devflow: prefix.
- */
-async function sweepOrphanedAssets(
-  dir: string,
-  knownNames: ReadonlySet<string>,
-  extractRegistryName: (entry: string) => string | null,
-): Promise<number> {
-  let scanned = 0;
-  try {
-    const entries = await fs.readdir(dir);
-    for (const entry of entries) {
-      const registryName = extractRegistryName(entry);
-      if (registryName === null) continue;
-      scanned++;
-      if (!knownNames.has(registryName)) {
-        try {
-          await fs.rm(path.join(dir, entry), { recursive: true, force: true });
-        } catch { /* ignore per-item removal errors */ }
-      }
-    }
-  } catch { /* directory absent or unreadable — not an error */ }
-  return scanned;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/targets/claude-code/installer.ts
+++ b/src/targets/claude-code/installer.ts
@@ -2,8 +2,7 @@ import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import type { PluginDefinition } from '../../core/plugins.js';
-import { DEVFLOW_PLUGINS, SKILL_NAMESPACE, prefixSkillName, unprefixSkillName, getAllSkillNames } from '../../core/plugins.js';
-import { LEGACY_AGENT_NAMES } from './legacy.js';
+import { DEVFLOW_PLUGINS, SKILL_NAMESPACE, prefixSkillName, unprefixSkillName, getAllSkillNames, getAllAgentNames, getAllCommandNames } from '../../core/plugins.js';
 import { skillsDir, agentsDir, rulesDir, commandsDir, scriptsDir } from '../../core/assets.js';
 import { getPackageRoot } from '../../core/paths.js';
 
@@ -240,6 +239,53 @@ export async function chmodRecursive(dir: string, mode: number): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Orphan sweep helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Sweep an install directory, removing every entry whose registry name (derived via
+ * extractRegistryName) is absent from knownNames.
+ *
+ * Design constraints:
+ * - knownNames MUST span ALL plugins, never just the selected subset — assets from
+ *   uninstalled plugins must survive a partial install. If you intersect with the
+ *   selected-plugin set here you have introduced a bug.
+ * - A missing or unreadable directory is a no-op (avoids PF-009).
+ * - Per-item removal failures are swallowed (avoids PF-009 blast-radius).
+ * - Only removes entries; never writes (avoids PF-011).
+ * - Returns the count of entries matched by the predicate. A count of 0 means the
+ *   directory was absent or contained no predicate-matching entries; callers can use
+ *   this to detect vacuous sweeps in tests.
+ *
+ * @param dir - The install directory to sweep.
+ * @param knownNames - Full registry set spanning ALL plugins.
+ * @param extractRegistryName - Maps a directory entry name to a registry key (the
+ *   name to look up in knownNames), or null to skip this entry entirely. For agents
+ *   and commands: strip the .md extension. For skills: strip the devflow: prefix.
+ */
+async function sweepOrphanedAssets(
+  dir: string,
+  knownNames: ReadonlySet<string>,
+  extractRegistryName: (entry: string) => string | null,
+): Promise<number> {
+  let scanned = 0;
+  try {
+    const entries = await fs.readdir(dir);
+    for (const entry of entries) {
+      const registryName = extractRegistryName(entry);
+      if (registryName === null) continue;
+      scanned++;
+      if (!knownNames.has(registryName)) {
+        try {
+          await fs.rm(path.join(dir, entry), { recursive: true, force: true });
+        } catch { /* ignore per-item removal errors */ }
+      }
+    }
+  } catch { /* directory absent or unreadable — not an error */ }
+  return scanned;
+}
+
+// ---------------------------------------------------------------------------
 // Script composer
 // ---------------------------------------------------------------------------
 
@@ -370,7 +416,9 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<Inst
   // Clean old Devflow files before installing
   spinner.message('Cleaning old files...');
   if (!isPartialInstall) {
-    // Commands and agents are plugin-scoped — only wipe on full install
+    // Commands and agents are plugin-scoped — only wipe on full install.
+    // On partial installs the registry-diff sweeps below handle stale entries
+    // without discarding assets from plugins not included in this run.
     const oldDirs = [
       path.join(claudeDir, 'commands', 'devflow'),
       path.join(claudeDir, 'agents', 'devflow'),
@@ -381,29 +429,21 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<Inst
         await fs.rm(dir, { recursive: true, force: true });
       } catch { /* ignore */ }
     }
-
-    // Sweep stale devflow:* skill dirs — remove any dir under ~/.claude/skills/
-    // whose bare name is no longer present in the registry. The devflow: namespace
-    // is exclusively Devflow's so removals are safe. Bare (pre-namespace) dirs are
-    // intentionally untouched — they are handled by the frozen LEGACY_SKILLS_* lists
-    // in legacy.ts (avoids PF-012: those lists are deletion manifests for pre-namespace
-    // paths and must not be modified). Shadow dirs (~/.devflow/skills/) are keyed by
-    // bare registry name and are unaffected by this sweep.
-    const skillsInstallDir = path.join(claudeDir, 'skills');
-    try {
-      const installedDirs = await fs.readdir(skillsInstallDir);
-      const knownSkillNames = new Set(getAllSkillNames());
-      for (const dir of installedDirs) {
-        if (!dir.startsWith(SKILL_NAMESPACE)) continue; // only our devflow: namespace
-        const bareName = unprefixSkillName(dir);
-        if (!knownSkillNames.has(bareName)) {
-          try {
-            await fs.rm(path.join(skillsInstallDir, dir), { recursive: true, force: true });
-          } catch { /* ignore individual removal errors */ }
-        }
-      }
-    } catch { /* skills dir absent or unreadable — not an error */ }
   }
+
+  // Sweep stale devflow:* skill dirs — ungated: runs on every install shape,
+  // including partial installs, so renamed/deleted skills are pruned promptly.
+  // knownNames spans ALL plugins (getAllSkillNames) so skills from uninstalled
+  // plugins survive a partial run. Bare (pre-namespace) dirs are intentionally
+  // untouched — they are handled by the frozen LEGACY_SKILLS_* lists in legacy.ts
+  // (avoids PF-012: those lists are deletion manifests for pre-namespace paths and
+  // must not be modified). Shadow dirs (~/.devflow/skills/) are keyed by bare
+  // registry name and are unaffected by this sweep.
+  await sweepOrphanedAssets(
+    path.join(claudeDir, 'skills'),
+    new Set(getAllSkillNames()),
+    (entry) => entry.startsWith(SKILL_NAMESPACE) ? unprefixSkillName(entry) : null,
+  );
 
   // Skills are universally installed — always clean both naming variants
   // to prevent duplicates (bare + prefixed) on upgrade or partial install
@@ -453,6 +493,15 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<Inst
     }
   }
 
+  // Sweep stale command files — ungated: runs on every install shape.
+  // knownNames spans ALL plugins (getAllCommandNames) so commands from uninstalled
+  // plugins survive a partial run. Only names absent from the full registry are removed.
+  await sweepOrphanedAssets(
+    commandsTarget,
+    new Set(getAllCommandNames()),
+    (entry) => entry.endsWith('.md') ? entry.slice(0, -'.md'.length) : null,
+  );
+
   // Install agents (deduplicated) from flat src/assets/agents/{name}.md.
   // A declared agent whose source file is absent is a build/packaging failure
   // and throws rather than silently skipping (matches command pattern).
@@ -482,12 +531,16 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<Inst
     }
   }
 
-  // Clean up legacy agent files (renamed or removed agents from prior versions)
-  for (const legacyAgent of LEGACY_AGENT_NAMES) {
-    try {
-      await fs.rm(path.join(agentsTarget, `${legacyAgent}.md`), { force: true });
-    } catch { /* ignore */ }
-  }
+  // Sweep stale agent files — ungated: runs on every install shape.
+  // knownNames spans ALL plugins (getAllAgentNames) so agents from uninstalled
+  // plugins survive a partial run. Only names absent from the full registry are removed.
+  // This supersedes the former LEGACY_AGENT_NAMES deletion loop — any name that leaves
+  // the registry is caught automatically without requiring manual list maintenance.
+  await sweepOrphanedAssets(
+    agentsTarget,
+    new Set(getAllAgentNames()),
+    (entry) => entry.endsWith('.md') ? entry.slice(0, -'.md'.length) : null,
+  );
 
   // Install skills from ALL plugins (skillsMap covers all plugins, not just selected).
   // Resolved from flat src/assets/skills/{name}/ (no per-plugin subdirectory).

--- a/src/targets/claude-code/installer.ts
+++ b/src/targets/claude-code/installer.ts
@@ -488,8 +488,6 @@ export async function installViaFileCopy(options: FileCopyOptions): Promise<Inst
   // Sweep stale agent files — ungated: runs on every install shape.
   // knownNames spans ALL plugins (getAllAgentNames) so agents from uninstalled
   // plugins survive a partial run. Only names absent from the full registry are removed.
-  // This supersedes the former LEGACY_AGENT_NAMES deletion loop — any name that leaves
-  // the registry is caught automatically without requiring manual list maintenance.
   await sweepOrphanedAssets(
     agentsTarget,
     new Set(getAllAgentNames()),

--- a/tests/init-logic.test.ts
+++ b/tests/init-logic.test.ts
@@ -26,7 +26,7 @@ import {
   ensureDevflowGitignore,
 } from '../src/targets/claude-code/post-install.js';
 import { installViaFileCopy, type Spinner } from '../src/targets/claude-code/installer.js';
-import { DEVFLOW_PLUGINS, buildAssetMaps, buildRulesMap } from '../src/core/plugins.js';
+import { DEVFLOW_PLUGINS, buildAssetMaps, buildRulesMap, getAllAgentNames, getAllCommandNames } from '../src/core/plugins.js';
 import type { RunMigrationsResult } from '../src/core/migrations.js';
 
 describe('parsePluginSelection', () => {
@@ -835,7 +835,9 @@ describe('installViaFileCopy cleanup (isPartialInstall)', () => {
     await expect(fs.access(path.join(claudeDir, 'agents', 'devflow', 'stale.md'))).rejects.toThrow();
   });
 
-  it('partial install (isPartialInstall=true) preserves existing commands and agents', async () => {
+  it('partial install (isPartialInstall=true) removes stale commands and agents via registry-diff sweep', async () => {
+    // 'stale' is absent from getAllCommandNames() and getAllAgentNames() — the
+    // registry-diff sweep should remove it on every install shape, not just full installs.
     await installViaFileCopy({
       plugins: [],
       claudeDir,
@@ -846,11 +848,91 @@ describe('installViaFileCopy cleanup (isPartialInstall)', () => {
       spinner: noopSpinner,
     });
 
-    // Stale files should still exist
-    const staleCommand = await fs.readFile(path.join(claudeDir, 'commands', 'devflow', 'stale.md'), 'utf-8');
-    expect(staleCommand).toBe('# stale');
-    const staleAgent = await fs.readFile(path.join(claudeDir, 'agents', 'devflow', 'stale.md'), 'utf-8');
-    expect(staleAgent).toBe('# stale');
+    // Stale files (names absent from registry) should be removed by the sweep
+    await expect(fs.access(path.join(claudeDir, 'commands', 'devflow', 'stale.md'))).rejects.toThrow();
+    await expect(fs.access(path.join(claudeDir, 'agents', 'devflow', 'stale.md'))).rejects.toThrow();
+  });
+});
+
+describe('partial install registry-diff sweep correctness', () => {
+  let tmpDir: string;
+  let claudeDir: string;
+  let devflowDir: string;
+  const noopSpinner: Spinner = { start() {}, stop() {}, message() {} };
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-sweep-test-'));
+    claudeDir = path.join(tmpDir, 'claude');
+    devflowDir = path.join(tmpDir, 'devflow');
+
+    // Pre-create the agents and commands directories so they exist before install.
+    await fs.mkdir(path.join(claudeDir, 'agents', 'devflow'), { recursive: true });
+    await fs.mkdir(path.join(claudeDir, 'commands', 'devflow'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes retired assets but preserves assets from uninstalled plugins on partial install', async () => {
+    // --- Arrange ---
+
+    // (b) A retired agent: 'shepherd' is listed in LEGACY_AGENT_NAMES and is NOT in
+    // getAllAgentNames(). The sweep must remove it.
+    const retiredAgentPath = path.join(claudeDir, 'agents', 'devflow', 'shepherd.md');
+    await fs.writeFile(retiredAgentPath, '# retired agent');
+
+    // (b) A retired command: 'review' is listed in LEGACY_COMMAND_NAMES and is NOT in
+    // getAllCommandNames(). The sweep must remove it.
+    const retiredCommandPath = path.join(claudeDir, 'commands', 'devflow', 'review.md');
+    await fs.writeFile(retiredCommandPath, '# retired command');
+
+    // (c) An agent from a plugin NOT selected for this partial run. 'coder' IS in
+    // getAllAgentNames() (covers all plugins) even though plugins: [] installs nothing.
+    // The sweep must preserve it — removing it would break a partial reinstall that
+    // leaves other plugins' assets untouched.
+    const knownAgents = getAllAgentNames();
+    expect(knownAgents.length).toBeGreaterThan(0); // (d) corpus non-empty guard
+    const survivingAgentName = knownAgents[0]!;
+    const survivingAgentPath = path.join(claudeDir, 'agents', 'devflow', `${survivingAgentName}.md`);
+    await fs.writeFile(survivingAgentPath, `# ${survivingAgentName} from uninstalled plugin`);
+
+    // Similarly for commands
+    const knownCommands = getAllCommandNames();
+    expect(knownCommands.length).toBeGreaterThan(0); // (d) corpus non-empty guard
+    const survivingCommandName = knownCommands[0]!;
+    const survivingCommandPath = path.join(claudeDir, 'commands', 'devflow', `${survivingCommandName}.md`);
+    await fs.writeFile(survivingCommandPath, `# ${survivingCommandName} from uninstalled plugin`);
+
+    // --- Act ---
+    await installViaFileCopy({
+      plugins: [],          // no plugins selected — pure partial install
+      claudeDir,
+      devflowDir,
+      skillsMap: new Map(),
+      agentsMap: new Map(),
+      isPartialInstall: true,
+      spinner: noopSpinner,
+    });
+
+    // --- Assert ---
+
+    // (b) Retired assets are gone — names absent from the full registry
+    await expect(fs.access(retiredAgentPath)).rejects.toThrow();
+    await expect(fs.access(retiredCommandPath)).rejects.toThrow();
+
+    // (c) Assets from uninstalled plugins survive — names present in the full registry
+    const agentContent = await fs.readFile(survivingAgentPath, 'utf-8');
+    expect(agentContent).toBe(`# ${survivingAgentName} from uninstalled plugin`);
+    const commandContent = await fs.readFile(survivingCommandPath, 'utf-8');
+    expect(commandContent).toBe(`# ${survivingCommandName} from uninstalled plugin`);
+
+    // (d) The directories are non-empty after the sweep — proves the sweep ran on a
+    // non-empty corpus and did not vacuously pass by finding nothing to examine.
+    const agentsAfter = await fs.readdir(path.join(claudeDir, 'agents', 'devflow'));
+    expect(agentsAfter.length).toBeGreaterThan(0);
+    const commandsAfter = await fs.readdir(path.join(claudeDir, 'commands', 'devflow'));
+    expect(commandsAfter.length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/init-logic.test.ts
+++ b/tests/init-logic.test.ts
@@ -877,13 +877,13 @@ describe('partial install registry-diff sweep correctness', () => {
   it('removes retired assets but preserves assets from uninstalled plugins on partial install', async () => {
     // --- Arrange ---
 
-    // (b) A retired agent: 'shepherd' is listed in LEGACY_AGENT_NAMES and is NOT in
-    // getAllAgentNames(). The sweep must remove it.
+    // (b) A retired agent: 'shepherd' is absent from getAllAgentNames().
+    // The sweep must remove it.
     const retiredAgentPath = path.join(claudeDir, 'agents', 'devflow', 'shepherd.md');
     await fs.writeFile(retiredAgentPath, '# retired agent');
 
-    // (b) A retired command: 'review' is listed in LEGACY_COMMAND_NAMES and is NOT in
-    // getAllCommandNames(). The sweep must remove it.
+    // (b) A retired command: 'review' is absent from getAllCommandNames().
+    // The sweep must remove it.
     const retiredCommandPath = path.join(claudeDir, 'commands', 'devflow', 'review.md');
     await fs.writeFile(retiredCommandPath, '# retired command');
 

--- a/tests/installer-new.test.ts
+++ b/tests/installer-new.test.ts
@@ -216,7 +216,7 @@ describe('installViaFileCopy — prefix-diff sweep', () => {
     ).rejects.toThrow();
   });
 
-  it('removes a stale devflow:* dir on partial (--plugin) install — sweep is now ungated', async () => {
+  it('removes a stale devflow:* dir on partial (--plugin) install — sweep is ungated', async () => {
     const claudeDir = path.join(tmpDir, 'claude');
     const devflowDir = path.join(tmpDir, 'devflow');
     const skillsDir = path.join(claudeDir, 'skills');
@@ -233,11 +233,11 @@ describe('installViaFileCopy — prefix-diff sweep', () => {
       devflowDir,
       skillsMap,
       agentsMap,
-      isPartialInstall: true, // partial install — sweep now runs on every shape
+      isPartialInstall: true, // partial install — sweep runs on every shape
       spinner,
     });
 
-    // The sweep is now ungated: stale prefixed dirs are removed on partial install too
+    // The sweep is ungated: stale prefixed dirs are removed on partial install
     await expect(
       fs.access(orphanDir),
       'stale prefixed dir must be removed even on partial install',

--- a/tests/installer-new.test.ts
+++ b/tests/installer-new.test.ts
@@ -216,7 +216,7 @@ describe('installViaFileCopy — prefix-diff sweep', () => {
     ).rejects.toThrow();
   });
 
-  it('leaves a stale devflow:* dir on partial (--plugin) install (isPartialInstall=true)', async () => {
+  it('removes a stale devflow:* dir on partial (--plugin) install — sweep is now ungated', async () => {
     const claudeDir = path.join(tmpDir, 'claude');
     const devflowDir = path.join(tmpDir, 'devflow');
     const skillsDir = path.join(claudeDir, 'skills');
@@ -233,14 +233,15 @@ describe('installViaFileCopy — prefix-diff sweep', () => {
       devflowDir,
       skillsMap,
       agentsMap,
-      isPartialInstall: true, // partial install — sweep does NOT run
+      isPartialInstall: true, // partial install — sweep now runs on every shape
       spinner,
     });
 
+    // The sweep is now ungated: stale prefixed dirs are removed on partial install too
     await expect(
       fs.access(orphanDir),
-      'stale prefixed dir must NOT be removed on partial install',
-    ).resolves.toBeUndefined();
+      'stale prefixed dir must be removed even on partial install',
+    ).rejects.toThrow();
   });
 
   it('leaves a bare (non-prefixed) dir untouched on full install (avoids PF-012)', async () => {

--- a/tests/orphan-sweep.test.ts
+++ b/tests/orphan-sweep.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { sweepOrphanedAssets } from '../src/core/orphan-sweep.js';
+
+/**
+ * Direct unit coverage for the shared registry-diff sweep helper.
+ *
+ * The helper is the single deletion primitive behind both the install pipeline
+ * (installer.ts: skills, commands, agents) and the uninstall pipeline
+ * (uninstall.ts: agents, commands). Its failure modes are all silent by design
+ * (avoids PF-009), so they must be pinned here rather than inferred from the
+ * two call sites.
+ *
+ * Every test asserts on a NON-EMPTY corpus, or explicitly asserts the returned
+ * scanned count to prove the sweep was not vacuous (avoids PF-018).
+ */
+describe('sweepOrphanedAssets', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-orphan-sweep-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  const stripMd = (entry: string): string | null =>
+    entry.endsWith('.md') ? entry.slice(0, -'.md'.length) : null;
+
+  it('removes entries whose registry name is absent and keeps the rest', async () => {
+    await fs.writeFile(path.join(dir, 'known.md'), 'keep', 'utf-8');
+    await fs.writeFile(path.join(dir, 'retired.md'), 'drop', 'utf-8');
+
+    const scanned = await sweepOrphanedAssets(dir, new Set(['known']), stripMd);
+
+    // Non-vacuity: both entries matched the predicate and were actually examined.
+    expect(scanned).toBe(2);
+    await expect(fs.access(path.join(dir, 'known.md'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(dir, 'retired.md'))).rejects.toThrow();
+  });
+
+  it('leaves entries the predicate rejects completely untouched', async () => {
+    // A bare (pre-namespace) skill dir stands in for anything the predicate skips:
+    // the sweep must never remove it, whatever the registry says (avoids PF-012).
+    await fs.mkdir(path.join(dir, 'bare-skill'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'README.txt'), 'not an asset', 'utf-8');
+    await fs.writeFile(path.join(dir, 'retired.md'), 'drop', 'utf-8');
+
+    const scanned = await sweepOrphanedAssets(dir, new Set<string>(), stripMd);
+
+    // Only retired.md matched the predicate — the other two were never candidates.
+    expect(scanned).toBe(1);
+    await expect(fs.access(path.join(dir, 'bare-skill'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(dir, 'README.txt'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(dir, 'retired.md'))).rejects.toThrow();
+  });
+
+  it('removes a directory entry recursively when the predicate accepts it', async () => {
+    // Skills install as prefixed DIRECTORIES, not files — rm must recurse.
+    // A neutral prefix stands in for the real namespace: the prefix is supplied by
+    // the caller's predicate, so the helper's behaviour does not depend on it.
+    const prefix = 'ns:';
+    const orphanSkill = path.join(dir, `${prefix}retired-skill`);
+    await fs.mkdir(orphanSkill, { recursive: true });
+    await fs.writeFile(path.join(orphanSkill, 'SKILL.md'), '# retired', 'utf-8');
+
+    const scanned = await sweepOrphanedAssets(
+      dir,
+      new Set(['live-skill']),
+      (entry) => entry.startsWith(prefix) ? entry.slice(prefix.length) : null,
+    );
+
+    expect(scanned).toBe(1);
+    await expect(fs.access(orphanSkill)).rejects.toThrow();
+  });
+
+  it('an EMPTY registry does not make the sweep skip work (guards accidental short-circuit)', async () => {
+    await fs.writeFile(path.join(dir, 'a.md'), 'x', 'utf-8');
+    await fs.writeFile(path.join(dir, 'b.md'), 'x', 'utf-8');
+
+    const scanned = await sweepOrphanedAssets(dir, new Set<string>(), stripMd);
+
+    expect(scanned).toBe(2);
+    expect(await fs.readdir(dir)).toEqual([]);
+  });
+
+  it('PF-013 / PF-009: a MISSING directory is a no-op, not an error', async () => {
+    // Fresh-project cold path — none of the install directories exist yet.
+    const missing = path.join(dir, 'never-created');
+    await expect(
+      sweepOrphanedAssets(missing, new Set(['anything']), stripMd),
+    ).resolves.toBe(0);
+    // The sweep must not create the directory it was pointed at (never writes).
+    await expect(fs.access(missing)).rejects.toThrow();
+  });
+
+  // A failing rm must degrade silently rather than propagate — one unguarded throw
+  // out of this helper would abort the entire install fan-out (avoids PF-009).
+  // Enforced by making the sweep directory unwritable, so readdir succeeds and every
+  // rm fails with EACCES. Not meaningful on Windows or as root.
+  const canRevokeWrite = process.platform !== 'win32' && process.getuid?.() !== 0;
+
+  it.skipIf(!canRevokeWrite)('PF-009: an rm that fails with EACCES is swallowed, not propagated', async () => {
+    await fs.writeFile(path.join(dir, 'retired-a.md'), 'x', 'utf-8');
+    await fs.writeFile(path.join(dir, 'retired-b.md'), 'x', 'utf-8');
+    await fs.chmod(dir, 0o500); // r-x: readdir works, unlink does not
+
+    try {
+      const scanned = await sweepOrphanedAssets(dir, new Set<string>(), stripMd);
+
+      // Non-vacuity: both entries were examined and both removals were attempted.
+      expect(scanned).toBe(2);
+      // The removals failed, so the entries are still there — proving the rm really
+      // did fail and the resolved promise is not a false negative.
+      await fs.chmod(dir, 0o700);
+      expect((await fs.readdir(dir)).sort()).toEqual(['retired-a.md', 'retired-b.md']);
+    } finally {
+      await fs.chmod(dir, 0o700);
+    }
+  });
+
+  it('PF-009: the sweep never rejects even when the path is a FILE, not a directory', async () => {
+    const filePath = path.join(dir, 'not-a-directory');
+    await fs.writeFile(filePath, 'x', 'utf-8');
+
+    // readdir on a file throws ENOTDIR — the helper must swallow it and report 0.
+    await expect(
+      sweepOrphanedAssets(filePath, new Set(['anything']), stripMd),
+    ).resolves.toBe(0);
+    // ...and must not have removed the file it could not read.
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+});

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -225,7 +225,10 @@ describe('optional plugin flag', () => {
     expect(resolve!.agents).toContain('validator');
     // resolver has been retired — should not appear in registry
     expect(resolve!.agents).not.toContain('resolver');
-    // retired agents must be in LEGACY_AGENT_NAMES so devflow init cleans up stale files
+    // resolver is in LEGACY_AGENT_NAMES for pre-registry-diff-sweep era cleanup; new
+    // retirements no longer require a manual list entry — the registry-diff sweep in
+    // the installer (sweepOrphanedAssets) removes any installed file whose name is
+    // absent from getAllAgentNames(), making LEGACY_AGENT_NAMES a historical deletion manifest
     expect(LEGACY_AGENT_NAMES).toContain('resolver');
     // apply-decisions skill declared so Triager can cite ADR/PF entries
     expect(resolve!.skills).toContain('apply-decisions');

--- a/tests/skill-namespace.test.ts
+++ b/tests/skill-namespace.test.ts
@@ -354,16 +354,18 @@ describe('installViaFileCopy skill lifecycle', () => {
     expect(stat.isFile()).toBe(true);
   });
 
-  it('partial install preserves commands and agents dirs', async () => {
-    // Seed existing command dir
+  it('partial install preserves commands from the full registry (dir is not wholesale-wiped)', async () => {
+    // 'implement' is in getAllCommandNames() — the registry-diff sweep must not remove it.
+    // This verifies both that the commands dir is not wholesale-wiped on partial install
+    // AND that the sweep correctly uses the full registry (not the selected-plugin subset).
     const commandsDir = path.join(claudeDir, 'commands', 'devflow');
     await fs.mkdir(commandsDir, { recursive: true });
-    await fs.writeFile(path.join(commandsDir, 'existing.md'), 'keep me');
+    await fs.writeFile(path.join(commandsDir, 'implement.md'), 'keep me');
 
     await runInstall({ isPartialInstall: true });
 
-    // Commands dir should still exist (only wiped on full install)
-    const content = await fs.readFile(path.join(commandsDir, 'existing.md'), 'utf-8');
+    // 'implement' is in the registry → survives the sweep
+    const content = await fs.readFile(path.join(commandsDir, 'implement.md'), 'utf-8');
     expect(content).toBe('keep me');
   });
 

--- a/tests/uninstall-logic.test.ts
+++ b/tests/uninstall-logic.test.ts
@@ -798,32 +798,70 @@ describe('removeDevFlowInstallArtifacts — proxy artifact removal (TEST-4)', ()
   it('(9c) residue after artifact-only removal exactly matches user-authored allow-list', async () => {
     // ── Install artifacts (must be removed) ──────────────────────────────────
     await fs.writeFile(path.join(devflowDir, 'manifest.json'), '{}', 'utf-8');
-    await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'migrations.json'), '{}', 'utf-8');
-    await fs.writeFile(path.join(devflowDir, 'hud.json'), '{}', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'proxy.json'), '{}', 'utf-8');
     await fs.mkdir(path.join(devflowDir, 'logs', 'project-slug'), { recursive: true });
     await fs.writeFile(path.join(devflowDir, 'logs', 'project-slug', '.hook-debug.log'), 'debug', 'utf-8');
     await fs.mkdir(path.join(devflowDir, 'cache', 'models'), { recursive: true });
+    await fs.mkdir(path.join(devflowDir, 'costs', 'sessions'), { recursive: true });
+    await fs.writeFile(path.join(devflowDir, 'costs', 'archive.jsonl'), '{}\n', 'utf-8');
 
     // ── User-authored files (must survive) ───────────────────────────────────
     await fs.mkdir(path.join(devflowDir, 'skills', 'my-skill'), { recursive: true });
     await fs.writeFile(path.join(devflowDir, 'skills', 'my-skill', 'SKILL.md'), '# Skill', 'utf-8');
+    await fs.mkdir(path.join(devflowDir, 'rules'), { recursive: true });
+    await fs.writeFile(path.join(devflowDir, 'rules', 'security.md'), '# Rule', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'preference-profile.md'), '# Profile', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'learning.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'hud.json'), '{}', 'utf-8');
 
     await removeDevFlowInstallArtifacts(devflowDir, false);
 
     // ── Equality assertion: only user-authored entries may remain ─────────────
     const remaining = new Set(await fs.readdir(devflowDir));
     // Install artifacts must be gone
-    for (const artifact of ['manifest.json', 'agent-models.json', 'migrations.json', 'hud.json', 'proxy.json', 'logs', 'cache']) {
+    for (const artifact of ['manifest.json', 'migrations.json', 'proxy.json', 'logs', 'cache', 'costs']) {
       expect(remaining.has(artifact), `install artifact "${artifact}" should be removed but was found in ${devflowDir}`).toBe(false);
     }
-    // User-authored files must survive
-    expect(remaining.has('skills')).toBe(true);
-    expect(remaining.has('preference-profile.md')).toBe(true);
-    // Exact equality: no unexpected entries remain
-    expect(remaining).toEqual(new Set(['skills', 'preference-profile.md']));
+    // Exact equality: nothing but user-authored state remains, and every enumerated
+    // user item survives an artifact-only pass. This is the executable form of the
+    // rule that removeDevFlowInstallArtifacts and enumerateUserDevFlowContent must
+    // never overlap — the artifact pass also runs on decline/cancel/--keep-docs.
+    expect(remaining).toEqual(new Set([
+      'skills',
+      'rules',
+      'preference-profile.md',
+      'learning.json',
+      'agent-models.json',
+      'hud.json',
+    ]));
+  });
+
+  // ─── TEST-9f: the two lists must be disjoint ────────────────────────────────
+  //
+  // enumerateUserDevFlowContent names what the confirm prompt says it is about to
+  // delete. removeDevFlowInstallArtifacts runs on the decline, cancel, non-interactive
+  // AND --keep-docs paths. An item on both lists is therefore deleted no matter what
+  // the user answers, which makes the prompt a lie and loses user config silently.
+
+  it('(9f) every item enumerated as user content survives an artifact-only removal', async () => {
+    await fs.mkdir(path.join(devflowDir, 'skills', 'my-skill'), { recursive: true });
+    await fs.mkdir(path.join(devflowDir, 'rules'), { recursive: true });
+    await fs.writeFile(path.join(devflowDir, 'rules', 'security.md'), '# Rule', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'preference-profile.md'), '', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'learning.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'hud.json'), '{}', 'utf-8');
+
+    const before = await enumerateUserDevFlowContent(devflowDir);
+    // Non-vacuity: the enumeration actually found every category on disk.
+    expect(before.length).toBe(6);
+
+    await removeDevFlowInstallArtifacts(devflowDir, false);
+
+    const after = await enumerateUserDevFlowContent(devflowDir);
+    expect(after).toEqual(before);
   });
 });
 
@@ -832,7 +870,6 @@ describe('removeDevFlowInstallArtifacts — proxy artifact removal (TEST-4)', ()
 //   retired and user-dropped files.
 // ---------------------------------------------------------------------------
 //
-// Now testable because removeAllDevFlow is exported (phase 2 step 1).
 // PF-018: these tests call the exported function directly — no CLI spawn, so
 // no ~/.claude guard is needed.
 
@@ -957,10 +994,9 @@ describe('removeSelectedPlugins — selective uninstall sweep (TEST-9b)', () => 
 // TEST-9e: isDevFlowInstalled — detects via any owned namespace (not just commands)
 // ---------------------------------------------------------------------------
 //
-// Previously keyed off commands/devflow only, so a commandless plugin install
-// (agents + skills, no commands) returned false and the uninstall flow exited
-// with "No Devflow installation found". Now checks agents/devflow and any
-// devflow:* skill directory in addition to commands/devflow.
+// Commandless plugin installs (agents + skills, no commands) must still be
+// detected. Checks all three namespaces: commands/devflow/, agents/devflow/,
+// and any devflow:* skill directory.
 
 describe('isDevFlowInstalled — multi-namespace detection (TEST-9e)', () => {
   let claudeDir: string;

--- a/tests/uninstall-logic.test.ts
+++ b/tests/uninstall-logic.test.ts
@@ -805,6 +805,9 @@ describe('removeDevFlowInstallArtifacts — proxy artifact removal (TEST-4)', ()
     await fs.mkdir(path.join(devflowDir, 'cache', 'models'), { recursive: true });
     await fs.mkdir(path.join(devflowDir, 'costs', 'sessions'), { recursive: true });
     await fs.writeFile(path.join(devflowDir, 'costs', 'archive.jsonl'), '{}\n', 'utf-8');
+    // agent-models.json is an install artifact (stale keys silently re-apply to
+    // renamed/deleted agents on reinstall — AC-P1-F4), NOT user-authored content.
+    await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
 
     // ── User-authored files (must survive) ───────────────────────────────────
     await fs.mkdir(path.join(devflowDir, 'skills', 'my-skill'), { recursive: true });
@@ -813,27 +816,27 @@ describe('removeDevFlowInstallArtifacts — proxy artifact removal (TEST-4)', ()
     await fs.writeFile(path.join(devflowDir, 'rules', 'security.md'), '# Rule', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'preference-profile.md'), '# Profile', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'learning.json'), '{}', 'utf-8');
-    await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'hud.json'), '{}', 'utf-8');
 
     await removeDevFlowInstallArtifacts(devflowDir, false);
 
     // ── Equality assertion: only user-authored entries may remain ─────────────
     const remaining = new Set(await fs.readdir(devflowDir));
-    // Install artifacts must be gone
-    for (const artifact of ['manifest.json', 'migrations.json', 'proxy.json', 'logs', 'cache', 'costs']) {
+    // Install artifacts must be gone (including agent-models.json — reclassified as artifact)
+    for (const artifact of ['manifest.json', 'migrations.json', 'proxy.json', 'logs', 'cache', 'costs', 'agent-models.json']) {
       expect(remaining.has(artifact), `install artifact "${artifact}" should be removed but was found in ${devflowDir}`).toBe(false);
     }
     // Exact equality: nothing but user-authored state remains, and every enumerated
     // user item survives an artifact-only pass. This is the executable form of the
     // rule that removeDevFlowInstallArtifacts and enumerateUserDevFlowContent must
     // never overlap — the artifact pass also runs on decline/cancel/--keep-docs.
+    // agent-models.json is intentionally ABSENT: it is an install artifact (AC-P1-F4),
+    // not user-authored content, so it does not appear in enumerateUserDevFlowContent.
     expect(remaining).toEqual(new Set([
       'skills',
       'rules',
       'preference-profile.md',
       'learning.json',
-      'agent-models.json',
       'hud.json',
     ]));
   });
@@ -851,12 +854,17 @@ describe('removeDevFlowInstallArtifacts — proxy artifact removal (TEST-4)', ()
     await fs.writeFile(path.join(devflowDir, 'rules', 'security.md'), '# Rule', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'preference-profile.md'), '', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'learning.json'), '{}', 'utf-8');
+    // agent-models.json is an INSTALL ARTIFACT (AC-P1-F4), not user content — it is
+    // present on disk here to prove the artifact pass removes it (does not survive),
+    // and it must NOT appear in the before/after enumeration.
     await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
     await fs.writeFile(path.join(devflowDir, 'hud.json'), '{}', 'utf-8');
 
     const before = await enumerateUserDevFlowContent(devflowDir);
-    // Non-vacuity: the enumeration actually found every category on disk.
-    expect(before.length).toBe(6);
+    // Non-vacuity: the enumeration found every USER-AUTHORED category on disk.
+    // Count is 5: skill shadows, rule shadows, preference-profile.md, learning.json, hud.json.
+    // agent-models.json is absent from the count — it is an artifact, not user content.
+    expect(before.length).toBe(5);
 
     await removeDevFlowInstallArtifacts(devflowDir, false);
 

--- a/tests/uninstall-logic.test.ts
+++ b/tests/uninstall-logic.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { computeAssetsToRemove, formatDryRunPlan, resolveSecurityRemovalDecision, enumerateUserDevFlowContent, resolveDevflowDirCleanup, removeDevFlowInstallArtifacts } from '../src/cli/commands/uninstall.js';
-import { DEVFLOW_PLUGINS, parsePluginSelection, type PluginDefinition } from '../src/core/plugins.js';
+import { computeAssetsToRemove, formatDryRunPlan, resolveSecurityRemovalDecision, enumerateUserDevFlowContent, resolveDevflowDirCleanup, removeDevFlowInstallArtifacts, removeAllDevFlow, removeSelectedPlugins, isDevFlowInstalled } from '../src/cli/commands/uninstall.js';
+import { DEVFLOW_PLUGINS, getAllAgentNames, parsePluginSelection, type PluginDefinition } from '../src/core/plugins.js';
 import { modelCacheDir } from '../src/core/cache.js';
 
 describe('computeAssetsToRemove', () => {
@@ -17,10 +17,13 @@ describe('computeAssetsToRemove', () => {
   });
 
   it('removes agents unique to selected plugins', () => {
-    // devflow-audit-claude has agent 'claude-md-auditor' which is unique to it
-    const auditPlugin = DEVFLOW_PLUGINS.find(p => p.name === 'devflow-audit-claude')!;
-    const { agents } = computeAssetsToRemove([auditPlugin], DEVFLOW_PLUGINS);
-    expect(agents).toContain('claude-md-auditor');
+    // devflow-bug-analysis has agent 'bug-analyzer' which is unique to it
+    const bugAnalysisPlugin = DEVFLOW_PLUGINS.find(p => p.name === 'devflow-bug-analysis')!;
+    // Non-empty assertion: guard against vacuous pass if the plugin is accidentally deleted
+    expect(bugAnalysisPlugin).toBeDefined();
+    expect(bugAnalysisPlugin.agents.length).toBeGreaterThan(0);
+    const { agents } = computeAssetsToRemove([bugAnalysisPlugin], DEVFLOW_PLUGINS);
+    expect(agents).toContain('bug-analyzer');
   });
 
   it('retains agents shared with remaining plugins', () => {
@@ -582,6 +585,46 @@ describe('resolveDevflowDirCleanup', () => {
     expect(artifactsOnly).toBe('artifacts-only');
     expect(prompt).toBe('prompt');
   });
+
+  // === keepDocs gate: suppresses the full ~/.devflow cleanup prompt (TEST-9d) ===
+  //
+  // --keep-docs must prevent the wipe prompt even when the session is interactive
+  // and user-authored content is present. Callers that pass keepDocs:true must
+  // fall through to removeDevFlowInstallArtifacts without prompting.
+
+  it('(9d) returns artifacts-only when keepDocs is true even with interactive TTY and user content', () => {
+    expect(resolveDevflowDirCleanup({
+      scope: 'user',
+      isTTY: true,
+      userContent: SOME_CONTENT,
+      devflowDir: VALID_DIR,
+      homeDir: HOME,
+      keepDocs: true,
+    })).toBe('artifacts-only');
+  });
+
+  it('(9d) returns artifacts-only when keepDocs is true and no user content', () => {
+    expect(resolveDevflowDirCleanup({
+      scope: 'user',
+      isTTY: true,
+      userContent: [],
+      devflowDir: VALID_DIR,
+      homeDir: HOME,
+      keepDocs: true,
+    })).toBe('artifacts-only');
+  });
+
+  it('(9d) keepDocs:false does not suppress the prompt (normal behavior preserved)', () => {
+    // Explicit false is same as omitting the field — prompt path still reachable.
+    expect(resolveDevflowDirCleanup({
+      scope: 'user',
+      isTTY: true,
+      userContent: SOME_CONTENT,
+      devflowDir: VALID_DIR,
+      homeDir: HOME,
+      keepDocs: false,
+    })).toBe('prompt');
+  });
 });
 
 // ─── TEST-4: removeDevFlowInstallArtifacts proxy artifact coverage ────────────
@@ -742,5 +785,233 @@ describe('removeDevFlowInstallArtifacts — proxy artifact removal (TEST-4)', ()
 
     // If uninstall drifts to a different path, writePath still exists → this fails.
     await expect(fs.access(writePath)).rejects.toThrow();
+  });
+
+  // ─── TEST-9c: ~/.devflow residue EQUALS allow-list of user-authored files ────────
+  //
+  // Asserts EQUALITY (not subset) so any install artifact that escapes the removal
+  // list causes a test failure. Proved non-vacuous: adding an unknown artifact
+  // ('mystery-artifact.json') to the setup BEFORE the equality assertion caused
+  // the test to go RED (mystery-artifact.json appeared in the remaining set),
+  // removing it restored GREEN — confirming the assertion enforces completeness.
+
+  it('(9c) residue after artifact-only removal exactly matches user-authored allow-list', async () => {
+    // ── Install artifacts (must be removed) ──────────────────────────────────
+    await fs.writeFile(path.join(devflowDir, 'manifest.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'agent-models.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'migrations.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'hud.json'), '{}', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'proxy.json'), '{}', 'utf-8');
+    await fs.mkdir(path.join(devflowDir, 'logs', 'project-slug'), { recursive: true });
+    await fs.writeFile(path.join(devflowDir, 'logs', 'project-slug', '.hook-debug.log'), 'debug', 'utf-8');
+    await fs.mkdir(path.join(devflowDir, 'cache', 'models'), { recursive: true });
+
+    // ── User-authored files (must survive) ───────────────────────────────────
+    await fs.mkdir(path.join(devflowDir, 'skills', 'my-skill'), { recursive: true });
+    await fs.writeFile(path.join(devflowDir, 'skills', 'my-skill', 'SKILL.md'), '# Skill', 'utf-8');
+    await fs.writeFile(path.join(devflowDir, 'preference-profile.md'), '# Profile', 'utf-8');
+
+    await removeDevFlowInstallArtifacts(devflowDir, false);
+
+    // ── Equality assertion: only user-authored entries may remain ─────────────
+    const remaining = new Set(await fs.readdir(devflowDir));
+    // Install artifacts must be gone
+    for (const artifact of ['manifest.json', 'agent-models.json', 'migrations.json', 'hud.json', 'proxy.json', 'logs', 'cache']) {
+      expect(remaining.has(artifact), `install artifact "${artifact}" should be removed but was found in ${devflowDir}`).toBe(false);
+    }
+    // User-authored files must survive
+    expect(remaining.has('skills')).toBe(true);
+    expect(remaining.has('preference-profile.md')).toBe(true);
+    // Exact equality: no unexpected entries remain
+    expect(remaining).toEqual(new Set(['skills', 'preference-profile.md']));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-9a: removeAllDevFlow — full uninstall empties agents/devflow including
+//   retired and user-dropped files.
+// ---------------------------------------------------------------------------
+//
+// Now testable because removeAllDevFlow is exported (phase 2 step 1).
+// PF-018: these tests call the exported function directly — no CLI spawn, so
+// no ~/.claude guard is needed.
+
+describe('removeAllDevFlow — full uninstall (TEST-9a)', () => {
+  let claudeDir: string;
+
+  beforeEach(async () => {
+    claudeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-test-claude-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(claudeDir, { recursive: true, force: true });
+  });
+
+  it('(9a) agents/devflow is gone after full uninstall regardless of what files are inside', async () => {
+    const agentsDir = path.join(claudeDir, 'agents', 'devflow');
+    await fs.mkdir(agentsDir, { recursive: true });
+    // Registry agent — a real agent name from the registry
+    await fs.writeFile(path.join(agentsDir, 'coder.md'), '---\nmodel: sonnet\n---\n', 'utf-8');
+    // Retired agent — a name no longer in any plugin
+    await fs.writeFile(path.join(agentsDir, 'old-retired-agent.md'), 'retired', 'utf-8');
+    // User-dropped file — arbitrary extra content in the dir
+    await fs.writeFile(path.join(agentsDir, 'user-notes.md'), 'notes', 'utf-8');
+
+    const devflowScriptsDir = path.join(claudeDir, 'scripts');
+    await removeAllDevFlow(claudeDir, devflowScriptsDir, false);
+
+    // agents/devflow must be gone (rm -rf on the whole dir)
+    await expect(fs.access(agentsDir)).rejects.toThrow();
+  });
+
+  it('(9a) commands/devflow is gone after full uninstall', async () => {
+    const commandsDir = path.join(claudeDir, 'commands', 'devflow');
+    await fs.mkdir(commandsDir, { recursive: true });
+    await fs.writeFile(path.join(commandsDir, 'implement.md'), '# implement', 'utf-8');
+    await fs.writeFile(path.join(commandsDir, 'old-legacy-cmd.md'), 'old', 'utf-8');
+
+    await removeAllDevFlow(claudeDir, path.join(claudeDir, 'scripts'), false);
+
+    await expect(fs.access(commandsDir)).rejects.toThrow();
+  });
+
+  it('(9a) completes without throwing even when all directories are absent', async () => {
+    // All target directories (commands, agents, rules, scripts) are absent — must be a no-op
+    await expect(
+      removeAllDevFlow(claudeDir, path.join(claudeDir, 'nonexistent-scripts'), false),
+    ).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-9b: removeSelectedPlugins — selective uninstall leaves no unclaimed files.
+// Registry-diff sweep removes orphaned agents/commands not in any plugin.
+// ---------------------------------------------------------------------------
+
+describe('removeSelectedPlugins — selective uninstall sweep (TEST-9b)', () => {
+  let claudeDir: string;
+
+  beforeEach(async () => {
+    claudeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-test-selective-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(claudeDir, { recursive: true, force: true });
+  });
+
+  it('(9b) sweeps orphaned (retired) agents that are not in any plugin registry', async () => {
+    const agentsDir = path.join(claudeDir, 'agents', 'devflow');
+    await fs.mkdir(agentsDir, { recursive: true });
+
+    // A real registry agent — must survive (it belongs to some plugin still installed)
+    const realAgent = getAllAgentNames()[0];
+    expect(realAgent).toBeDefined(); // non-vacuous: registry is non-empty
+    await fs.writeFile(path.join(agentsDir, `${realAgent}.md`), 'real agent', 'utf-8');
+
+    // An orphaned agent name that is NOT in any plugin — must be swept
+    const orphanName = '__orphaned_test_agent_not_in_any_plugin__';
+    await fs.writeFile(path.join(agentsDir, `${orphanName}.md`), 'orphaned', 'utf-8');
+
+    // Run selective uninstall with any plugin (the sweep covers ALL plugins' names)
+    const anyPlugin = DEVFLOW_PLUGINS[0];
+    await removeSelectedPlugins(claudeDir, [anyPlugin], false);
+
+    // Orphaned agent must be swept away
+    await expect(
+      fs.access(path.join(agentsDir, `${orphanName}.md`)),
+    ).rejects.toThrow();
+
+    // Real registry agent must survive (it's in the knownNames set)
+    await expect(
+      fs.access(path.join(agentsDir, `${realAgent}.md`)),
+    ).resolves.not.toThrow();
+  });
+
+  it('(9b) commands: orphaned command files are swept; registry commands survive', async () => {
+    const commandsDir = path.join(claudeDir, 'commands', 'devflow');
+    await fs.mkdir(commandsDir, { recursive: true });
+
+    // A known (non-orphaned) command: 'implement' is in getAllCommandNames()
+    await fs.writeFile(path.join(commandsDir, 'implement.md'), '# implement', 'utf-8');
+
+    // An orphaned command not in any plugin
+    const orphanCmd = '__orphaned_command_not_in_registry__';
+    await fs.writeFile(path.join(commandsDir, `${orphanCmd}.md`), 'orphaned', 'utf-8');
+
+    const anyPlugin = DEVFLOW_PLUGINS[0];
+    await removeSelectedPlugins(claudeDir, [anyPlugin], false);
+
+    // Orphaned command swept
+    await expect(
+      fs.access(path.join(commandsDir, `${orphanCmd}.md`)),
+    ).rejects.toThrow();
+
+    // 'implement' survives (it's in the registry even if not removed by this plugin selection)
+    await expect(
+      fs.access(path.join(commandsDir, 'implement.md')),
+    ).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-9e: isDevFlowInstalled — detects via any owned namespace (not just commands)
+// ---------------------------------------------------------------------------
+//
+// Previously keyed off commands/devflow only, so a commandless plugin install
+// (agents + skills, no commands) returned false and the uninstall flow exited
+// with "No Devflow installation found". Now checks agents/devflow and any
+// devflow:* skill directory in addition to commands/devflow.
+
+describe('isDevFlowInstalled — multi-namespace detection (TEST-9e)', () => {
+  let claudeDir: string;
+
+  beforeEach(async () => {
+    claudeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'devflow-test-detect-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(claudeDir, { recursive: true, force: true });
+  });
+
+  it('(9e) returns true when agents/devflow exists but commands/devflow is absent', async () => {
+    await fs.mkdir(path.join(claudeDir, 'agents', 'devflow'), { recursive: true });
+    await fs.writeFile(
+      path.join(claudeDir, 'agents', 'devflow', 'coder.md'),
+      '---\nmodel: sonnet\n---',
+      'utf-8',
+    );
+    // commands/devflow intentionally absent
+
+    const result = await isDevFlowInstalled(claudeDir);
+    expect(result).toBe(true);
+  });
+
+  it('(9e) returns true when a devflow: skill dir exists but commands/devflow is absent', async () => {
+    await fs.mkdir(path.join(claudeDir, 'skills', 'devflow:software-design'), { recursive: true });
+    // commands/devflow and agents/devflow intentionally absent
+
+    const result = await isDevFlowInstalled(claudeDir);
+    expect(result).toBe(true);
+  });
+
+  it('(9e) returns true when commands/devflow exists (existing behavior preserved)', async () => {
+    await fs.mkdir(path.join(claudeDir, 'commands', 'devflow'), { recursive: true });
+
+    const result = await isDevFlowInstalled(claudeDir);
+    expect(result).toBe(true);
+  });
+
+  it('(9e) returns false when none of the owned namespaces are present', async () => {
+    // Empty claudeDir — no Devflow artifacts
+    const result = await isDevFlowInstalled(claudeDir);
+    expect(result).toBe(false);
+  });
+
+  it('(9e) returns false when skills dir has only non-devflow entries', async () => {
+    // A skill dir without the devflow: prefix must not trigger detection
+    await fs.mkdir(path.join(claudeDir, 'skills', 'other-plugin:some-skill'), { recursive: true });
+
+    const result = await isDevFlowInstalled(claudeDir);
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
PR 1 of 4 in the `wave/agent-roster` integration wave. This is the foundation PR: it replaces hand-maintained legacy-name cleanup with a self-maintaining registry-diff sweep, so the later PRs in this wave (removing `audit-claude`, renaming 13 agents) need no legacy-list entries at all.

## Install side
- New shared `sweepOrphanedAssets` helper in `src/core/orphan-sweep.ts`; one compute site, consumed by both the installer and uninstaller.
- Replaced the `LEGACY_AGENT_NAMES` deletion loop with an ungated registry-diff sweep over `~/.claude/agents/devflow/`.
- Added the equivalent sweep for commands, wiring up `getAllCommandNames()` — which existed but was previously unused anywhere in `src/`.
- Ungated the existing skills sweep so it runs on partial (`--plugin`) installs too.

Safe because `getAllAgentNames()`/`getAllCommandNames()` span **all** plugins regardless of selection: assets belonging to unselected plugins survive, and only names that left the registry entirely are removed.

## Uninstall side
- `removeAllDevFlow`, `removeSelectedPlugins` and `isDevFlowInstalled` are now exported and therefore testable.
- Registry-diff sweep added to the selective uninstall path, which previously left retired assets behind permanently.
- `revertExternalAgents` now runs on the selective path, before agent files are removed.
- `--keep-docs` is honored in `resolveDevflowDirCleanup` — previously an active data-loss path that could prompt to wipe skill shadows and `preference-profile.md`.
- `isDevFlowInstalled` no longer keys off `commands/devflow` alone, so a commandless plugin set is detected instead of exiting 1.
- Artifact list completed: `migrations.json`, `agent-models.json`, `costs/`, `logs/`, `cache/` parent, proxy artifacts.
- A containment precondition now prevents any artifact path from resolving to `~/.devflow` itself or above it.

## Classification invariant
`enumerateUserDevFlowContent` (user state, survives unless explicitly confirmed) and the install-artifact list (removed on every path, including decline/cancel/`--keep-docs`) are now **disjoint**, enforced by a test. `agent-models.json` is an install artifact — leaving it behind meant a reinstall silently re-applied stale per-agent overrides. `hud.json` is user state.

## Testing
85 files / 2,716 tests / 0 failures (baseline 84 / 2,693; +23 fully accounted per-file). Build and `tsc --noEmit` clean.

New tests deliberately target the **partial-install** path — on a full install the pre-existing wholesale wipe deletes planted files anyway, so a green test there would prove nothing about the sweep. Each sweep test also asserts an unselected plugin's asset **survived**, which is what distinguishes "the sweep worked" from "the wipe ran". Non-vacuity was proven by red→green falsification for the sweep tests, the residue allow-list equality test, and the disjointness test.

## Notes
- `LEGACY_SKILL_NAMES` and the `LEGACY_SKILLS_*` lists are untouched and must stay so: they are deletion manifests for pre-namespace bare dirs outside the swept namespace.
- `LEGACY_AGENT_NAMES` now has no production consumer. Left in place deliberately rather than churned in this PR.
- Known limitation, out of scope: `revertExternalAgents` on the selective path reverts every installed agent rather than only those being removed, so surviving agents lose GPT frontmatter until the next `devflow init`. Fixing it is an API change to `RevertOptions`.