### PR TITLE
fix(build): set execute bit on dist/cli.js in prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:mds": "npx tsx scripts/build-mds.ts",
     "dev": "tsc --watch",
     "cli": "node dist/cli.js",
-    "prepublishOnly": "rm -rf dist && npm run build:cli && npm run build:mds",
+    "prepublishOnly": "rm -rf dist && npm run build:cli && npm run build:mds && chmod +x dist/cli.js",
     "version:bump": "npx tsx scripts/bump-version.ts",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

`dist/cli.js` (the `devflow` bin entry) was published with mode **0644** because `tsc` never sets the execute bit and the old `prepublishOnly` script never chmodded it. npm ≥7 silently masks this by auto-chmodding on install, but **npm 6 and constrained environments** (Docker non-root users, certain CI runners) break because the bin is not executable.

## Changes

- `package.json` `prepublishOnly`: appended `&& chmod +x dist/cli.js` to the existing build pipeline.

No source files, no version bump, no other changes.

## Breaking Changes

None.

## Reviewer Focus Areas

Single-line script change; confirm the script reads:
```
rm -rf dist && npm run build:cli && npm run build:mds && chmod +x dist/cli.js
```

## Verification

```
$ npm run prepublishOnly   # build succeeded, 13 MDS commands compiled
$ ls -l dist/cli.js
-rwxr-xr-x  1 dean  staff  3930 Aug 23 23:10 dist/cli.js
```

Full test suite: 96 test files / 3317 tests — all passed.
