### PR TITLE
fix(agents): sharpen Skim agent usage discipline and heatmap scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Orchestrator charter — self-contained delegation**: added an operating rule requiring every subagent delegation to be self-contained (goal, constraints, relevant session facts, exact paths). Deliverables that draw on the conversation (issues, PRs, reports) must carry the substance in the prompt rather than a pointer to it. Charter grows from 2177 → 2452 bytes (~600 tokens), well within the 4096-byte runtime limit.
+- **Skim agent**: one-view-per-file discipline (pseudo/Read tiers), branch-scoped heatmap (`--diff`, `--window`, `--top`), PATH-first `skim` invocation with `npx rskim` fallback, prose/config skim note
 
 ---
 

--- a/src/assets/agents/skim.md
+++ b/src/assets/agents/skim.md
@@ -9,7 +9,7 @@ skills:
 
 # Skim Agent
 
-You are a codebase orientation specialist. You use `npx rskim` exclusively for code exploration — never Grep, Glob, or manual file searches. Your output gives implementation agents a clear map of relevant files, functions, and integration points.
+You are a codebase orientation specialist. You use the skim CLI exclusively for code exploration — never Grep, Glob, or manual file searches. Prefer the `skim` binary when on PATH (`command -v skim`); fall back to `npx rskim`. Examples below show `npx rskim` — substitute `skim` when available. Your output gives implementation agents a clear map of relevant files, functions, and integration points.
 
 ## Input Context
 
@@ -57,13 +57,16 @@ When the task modifies existing code (refactor, bugfix, extension), run:
 npx rskim heatmap --insights
 ```
 
-Scope with `--path <dir>` when targeting a subdirectory. Skip for greenfield or pure-research tasks. If git history is unavailable (non-git/shallow clone), note it and continue.
+On a feature branch, prefer `npx rskim heatmap --insights --diff <base-branch>` to scope findings to the files the branch touches. Scope with `--path <dir>` when targeting a subdirectory; tune recency with `--window sprint|month|quarter` and result count with `--top N`. Skip for greenfield or pure-research tasks. If git history is unavailable (non-git/shallow clone), note it and continue.
 
 ### Step 5: Targeted Detail
 
-For the few specific files that need content (not just structure), use the **Read tool directly** — do not use rskim for this.
+For the few specific files that need more than structure, pick exactly one view per file:
 
-Principle: *rskim for structure, Read for content — never both on the same file; never use rskim as a Read substitute.*
+- Need the logic but not the exact text → `npx rskim <file> --mode pseudo`
+- Need exact content (edit targets, precise behavior) → the **Read tool directly**
+
+If you already know a file needs content, go straight to Read — don't skim it first. The only valid skim→Read sequence is across *different* files (skim several to orient, then Read the one that matters). Skimming and then Reading the same file pays for it twice.
 
 ### Step 6: Project Knowledge
 
@@ -88,6 +91,10 @@ Produce the orientation summary in the output format below.
 | `--mode signatures` | API/function signatures only |
 | `--mode types` | Type definitions only — maximum compression |
 | `heatmap --insights` | Threshold-filtered risk findings from git history |
+| `heatmap --diff <BASE>` | Limit findings to files changed vs BASE (three-dot diff) |
+| `heatmap --window <preset>` | Recency window: `sprint`/`month`/`quarter`/`half`/`year`/`all` |
+
+skim also handles prose/config files (`.md`, `.json`, `.yaml`, `.toml`) — the structural view shows headings/keys, useful for large specs and config directories.
 
 ## Output
 
@@ -123,7 +130,7 @@ Produce the orientation summary in the output format below.
 ## Principles
 
 1. **Speed and focus** — Get oriented quickly on what's relevant; task-focused exploration only
-2. **rskim for structure, Read for content** — never both on the same file
+2. **One view per file** — structure via skim, logic via `--mode pseudo`, exact content via Read; never pay for the same file twice, and never skim a file you already know you'll Read
 3. **Be decisive** — Make confident recommendations about where to integrate
 4. **Token efficiency** — Use rskim token budgets and stats to show compression ratio
 


### PR DESCRIPTION
## Summary

Five targeted edits to `src/assets/agents/skim.md` that sharpen the Skim agent's file-reading discipline, heatmap usage, and CLI invocation. No build step required — agent assets are the single source of truth.

Behavioral guidance was the gap: the cascade description (`full → minimal → structure → signatures → types`) was already correct per `skim --help` 2.11.0. These edits address what was missing.

## Changes

**Edit 1 — PATH-first invocation**: Intro paragraph now instructs the agent to prefer the `skim` binary when on PATH (`command -v skim`) and fall back to `npx rskim`, so installations with the binary avoid the npm spawning overhead.

**Edit 2 — Branch-scoped heatmap**: Step 4 guidance adds `--diff <base-branch>` for feature-branch runs to scope findings to touched files only, plus `--window sprint|month|quarter` for recency tuning and `--top N` for result-count control.

**Edit 3 — One-view-per-file discipline**: Step 5 replaces the binary skim/Read split with a three-tier model: structure (default skim), logic (`--mode pseudo`), or exact content (Read tool). Includes explicit anti-pattern guidance: don't skim a file you already know you'll Read.

**Edit 4 — Reference table and prose/config note**: Two heatmap rows added (`--diff` and `--window`). A sentence below the table notes that skim handles `.md`/`.json`/`.yaml`/`.toml` files with heading/key structural views.

**Edit 5 — Principle 2 reworded**: From the binary "rskim for structure, Read for content" to the three-tier "One view per file" formulation that matches Step 5.

## Verification

Empirically verified against `skim --help` 2.11.0: cascade (`full → minimal → structure → signatures → types`), `--diff`, `--window`, `--top`, and prose/config support are all present. The cascade description in the file was already correct — behavioral guidance was the only gap.

Test suite: **all 30 test files passed, EXIT=0** (177 shell-hook tests, 136 proxy tests, 87 agent-frontmatter tests, and 22 other suites — no failures, no flakes on this run).
