### PR TITLE
fix(resolve): render base branch in summaries and repair BRANCH_INFO phase DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **`/resolve` DUPLICATE verdict**: `/resolve` now collapses duplicate cross-reviewer findings via a new `DUPLICATE` triage verdict — resolution-summary counts unique issues, with a `Duplicates Collapsed` statistics row and a `## Duplicates` section for traceability.
 
+### Fixed
+- **`/resolve` base branch token**: resolution summaries now render the base branch name instead of a literal `{base}` token. Step 0b was not extracting `base_branch` while the summary template referenced it.
+
 ---
 
 ## [2.2.0] - 2026-08-25

--- a/src/assets/commands/resolve.mds
+++ b/src/assets/commands/resolve.mds
@@ -56,7 +56,7 @@ In multi-worktree mode, spawn all pre-flight agents **in a single message** (par
 
 **If BLOCKED:** In single-worktree mode, stop and report the blocker to user. If no reviews found, suggest `/code-review` or `/bug-analysis` first. In multi-worktree mode, report the failure but continue with other worktrees.
 
-**Extract from response:** `branch`, `branch_slug`, `pr_number`, `review_count`, `diff_files` per worktree.
+**Extract from response:** `branch`, `base_branch`, `branch_slug`, `pr_number`, `review_count`, `diff_files` per worktree.
 
 **Fetch PR body** (after extracting `pr_number`):
 ```bash
@@ -138,7 +138,7 @@ Issues are extracted from `\{TARGET_DIR\}` only — never cross-reference review
 ### Phase 1b: Fetch External Review Threads (Compliance-gated)
 
 **Produces:** THREAD_MAP
-**Requires:** PR_INFO, COMPLIANCE_SKILL_INSTALLED
+**Requires:** BRANCH_INFO, COMPLIANCE_SKILL_INSTALLED
 
 Skip this phase if `COMPLIANCE_SKILL_INSTALLED` is false.
 
@@ -157,7 +157,7 @@ Parse `THREAD_MAP` from Git agent output. If Git agent returns `TRACEABILITY: DE
 ### Phase 2: Global Triage
 
 **Produces:** TRIAGE_RESULTS
-**Requires:** ISSUES, DIFF_FILES, DECISIONS_CONTEXT, FEATURE_KNOWLEDGE, PR_DESCRIPTION, BRANCH_INFO
+**Requires:** ISSUES, DIFF_FILES, DECISIONS_CONTEXT, FEATURE_KNOWLEDGE, PR_DESCRIPTION
 
 Spawn a single global Triage agent for ALL issues:
 
@@ -208,7 +208,7 @@ Otherwise, batch FIX_NOW issues for Code agent execution. **DUPLICATE issues are
 ### Phase 4: Fix (Code agent × N)
 
 **Produces:** CODE_AGENT_RESULTS
-**Requires:** BATCHES, DECISIONS_CONTEXT, FEATURE_KNOWLEDGE, BRANCH_INFO
+**Requires:** BATCHES, DECISIONS_CONTEXT, FEATURE_KNOWLEDGE
 
 For each batch, spawn Code agent with `OPERATION: issue-fix` and `PUSH: false`:
 
@@ -237,7 +237,7 @@ Collect from each Code agent:
 ### Phase 5: Write resolution-summary.md
 
 **Produces:** RESOLUTION_FILE (early write for compaction safety)
-**Requires:** TRIAGE_RESULTS, CODE_AGENT_RESULTS
+**Requires:** TRIAGE_RESULTS, CODE_AGENT_RESULTS, TARGET_DIR, BRANCH_INFO
 
 **Immediately write `resolution-summary.md`** to `\{TARGET_DIR\}` using the Write tool. Do this now — not in Phase 9 — while results are fresh in context. This ensures the record is persisted even if later phases (Simplify, Verification Gate, CI gate, Tech Debt) trigger context compaction.
 
@@ -403,7 +403,7 @@ Update `## Third-Party Threads` section in resolution-summary.md with thread res
 ### Phase 9c: Merge Readiness (Compliance-gated, Report-only)
 
 **Produces:** MERGE_READINESS_REPORT
-**Requires:** PR_INFO, COMPLIANCE_SKILL_INSTALLED
+**Requires:** BRANCH_INFO, COMPLIANCE_SKILL_INSTALLED
 
 Skip this phase if `COMPLIANCE_SKILL_INSTALLED` is false.
 
@@ -422,7 +422,7 @@ If Git agent returns `TRACEABILITY: DEGRADED`: warn, proceed to Phase 10.
 
 ### Phase 10: Report
 
-**Requires:** TARGET_DIR
+**Requires:** BRANCH_INFO, TARGET_DIR
 
 The resolution summary was already written to `\{TARGET_DIR\}/resolution-summary.md` in Phase 5 (updated by Phase 7 and Phase 9). Display results to the user:
 
@@ -563,7 +563,7 @@ Written in Phase 5 (Collect Results) to `\{TARGET_DIR\}/resolution-summary.md`:
 ```markdown
 # Resolution Summary
 
-**Branch**: {branch} -> {base}
+**Branch**: {branch} -> {base_branch}
 **Date**: {timestamp}
 **Review**: {TARGET_DIR}
 **Command**: /resolve


### PR DESCRIPTION
## Summary

- Resolution summaries were rendering a literal `{base}` token instead of the actual base branch name — every `resolution-summary.md` ever produced by `/resolve` contained the unresolved placeholder.
- Four phase-dependency annotation defects in `resolve.mds` repaired so the command's internal DAG is self-consistent and matches the sibling commands (`bug-analysis.mds`, `code-review.mds`).

## What Was Broken

### 1. Unrendered template token (user-visible)
The resolution-summary template contained `**Branch**: {branch} -> {base}`, but Step 0b's extract list never declared `base_branch` as an output variable. Every generated `resolution-summary.md` rendered `{base}` literally. Fixed by extracting `base_branch` in Step 0b and renaming the template token to `{base_branch}`.

Sibling-file evidence: `bug-analysis.mds:247` carries the byte-identical template line and works correctly because its Step 0b already extracts `base_branch`. The Git agent's `validate-branch` op returns `**Base**: {base_branch}` (`src/assets/agents/git.md:177-181`) — the value was available and being discarded.

### 2. Dangling `PR_INFO` requirement (PF-024 class)
Phases 1b and 9c declared `**Requires:** PR_INFO`, but `PR_INFO` has no producer anywhere in `resolve.mds` or its MDS partials. Renamed to `BRANCH_INFO`, which Step 0b does produce and which already bundles `pr_number` (matching `bug-analysis.mds`).

### 3. Over-declaration of `BRANCH_INFO`
Phases 2 and 4 declared `BRANCH_INFO` but consume no branch value: `triage.md` declares no branch input, and Phase 4 Code spawns with `CREATE_PR: false` + `PUSH: false`, making `code.md`'s only `BASE_BRANCH` use unreachable. Removed from both.

### 4. Under-declaration at real consumption sites
Phases 5 and 10 consume `BRANCH_INFO` (Phase 5 also consumes `TARGET_DIR`) without declaring it in `**Requires:**`. Both declarations added, ordered to match `code-review.mds:274` and `bug-analysis.mds:239`.

## Net effect

`BRANCH_INFO` is now produced once (Step 0b) and required at exactly five genuine consumption sites. The DAG is internally consistent. This is a PF-024-class seam fix — the command→agent boundary is an untyped, unchecked call site where annotation rot is the only guardrail.

## Verification

- `npm run build:mds` — 13 commands compiled, 0 errors, 0 warnings.
- 597 tests across 23 files passing (`tests/resolve/`, `tests/ambient.test.ts`, `tests/build-mds.test.ts`, `tests/agent-name-guards.test.ts`, `tests/decisions/`, `tests/bug-analysis/`).
- No test pins any of the changed literals.

## Related Issues

None.