### PR TITLE
chore(release): require explicit version confirmation before dispatch

### DIFF
--- a/.release/RELEASE-FLOW.md
+++ b/.release/RELEASE-FLOW.md
@@ -10,10 +10,14 @@ Learned by `/release` on 2026-08-23 from: `package.json`, `.github/workflows/rel
 
 ## Version Strategy
 
-- `semver-auto`: derive bump from conventional commits since last tag (`!`/BREAKING → major)
+- `semver-auto`: derive a PROPOSED bump from conventional commits since last tag
+  (`!`/BREAKING → major). ALWAYS confirm the resulting version with the user before
+  dispatch, even when derivation is unambiguous (user directive, 2026-09-02) — present
+  the version explicitly, not just folded into the release-plan summary.
   Also scan squash-commit BODIES for breaking-change sections (`## Breaking Changes`) —
-  PR templates document them there without the `!` marker; confirm major-vs-minor with
-  the user when found (2.1.0 shipped such changes as a minor by explicit user choice)
+  PR templates document them there without the `!` marker; a section stating "None" is
+  a negative declaration, not a breaking change (2.1.0 shipped real breaking changes as
+  a minor by explicit user choice; 2.4.0 resolved two "None" sections as minor)
 - Tag format: `vX.Y.Z` (annotated). Release title: `vX.Y.Z`. No `v` prefix in CI input.
 - Branching model: main-only, squash merges, no version PRs. CI bot commits directly to main
   (ruleset bypass). `.devflow/conventions.md` absent — heuristics above learned from history.


### PR DESCRIPTION
## Summary
Records a user directive in the learned release config (`.release/RELEASE-FLOW.md`): the version derived by semver-auto is a **proposal** — it must always be confirmed explicitly with the user before dispatching the release workflow, even when derivation is unambiguous.

## Changes
- Version Strategy: semver-auto derives a proposed bump; always confirm the resulting version explicitly with the user before dispatch (directive from the v2.4.0 release, 2026-09-02)
- Clarify that a squash-body `## Breaking Changes` section stating "None" is a negative declaration, not a breaking change (2.4.0 resolved two such sections as minor)

## Breaking Changes
None.

## Testing
Config prose only — consumed by the `/release` orchestrator; no code paths affected.